### PR TITLE
Adding Glue, SNS, and SQS to Inventory

### DIFF
--- a/cli/aws.go
+++ b/cli/aws.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/fsx"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/grafana"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -32,6 +33,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/fatih/color"
 	"github.com/kyokomi/emoji"
@@ -182,6 +185,9 @@ var (
 				CloudfrontClient:     cloudfront.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
 				AppRunnerClient:      apprunner.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
 				LightsailClient:      lightsail.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				GlueClient:           glue.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				SNSClient:            sns.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				SQSClient:            sqs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
 
 				Caller:     utils.AWSWhoami(AWSProfile),
 				AWSRegions: AWSRegions,
@@ -491,6 +497,9 @@ var (
 			sagemakerClient := sagemaker.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
 			ecrClient := ecr.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
 			ssmClient := ssm.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
+			glueClient := glue.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
+			snsClient := sns.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
+			sqsClient := sqs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
 
 			fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("Getting a lay of the land, aka \"What regions is this account using?\""))
 			inventory2 := aws.Inventory2Module{
@@ -515,6 +524,9 @@ var (
 				CloudfrontClient:     cloudfrontClient,
 				AppRunnerClient:      appRunnerClient,
 				LightsailClient:      lightsailClient,
+				GlueClient:           glueClient,
+				SNSClient:            snsClient,
+				SQSClient:            sqsClient,
 
 				Caller:     utils.AWSWhoami(AWSProfile),
 				AWSRegions: AWSRegions,

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/aquasecurity/table v1.8.0
-	github.com/aws/aws-sdk-go-v2 v1.16.11
+	github.com/aws/aws-sdk-go-v2 v1.16.15
 	github.com/aws/aws-sdk-go-v2/config v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.15.6
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.12.5
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.14.5
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.18.5
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.24.1
+	github.com/aws/aws-sdk-go-v2/service/glue v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.9.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.5
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.23.1
@@ -39,9 +40,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.13.0
+	github.com/aws/aws-sdk-go-v2/service/sns v1.18.0
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.19.9
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.14.0
-	github.com/aws/smithy-go v1.12.1
+	github.com/aws/smithy-go v1.13.3
 	github.com/fatih/color v1.13.0
 	github.com/go-openapi/strfmt v0.21.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/aws/aws-sdk-go-v2 v1.16.4/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX
 github.com/aws/aws-sdk-go-v2 v1.16.5/go.mod h1:Wh7MEsmEApyL5hrWzpDkba4gwAPc5/piwLVLFnCxp48=
 github.com/aws/aws-sdk-go-v2 v1.16.11 h1:xM1ZPSvty3xVmdxiGr7ay/wlqv+MWhH0rMlyLdbC0YQ=
 github.com/aws/aws-sdk-go-v2 v1.16.11/go.mod h1:WTACcleLz6VZTp7fak4EO5b9Q4foxbn+8PIz3PmyKlo=
+github.com/aws/aws-sdk-go-v2 v1.16.15 h1:2sInOWGE4HV54R90Pj8QgqBBw3Qf1I0husqbqjPZzys=
+github.com/aws/aws-sdk-go-v2 v1.16.15/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.2.0 h1:scBthy70MB3m4LCMFaBcmYCyR2XWOz6MxSfdSu/+fQo=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.2.0/go.mod h1:oZHzg1OVbuCiRTY0oRPM+c2HQvwnFCGJwKeSqqAJ/yM=
 github.com/aws/aws-sdk-go-v2/config v1.13.0 h1:1ij3YPk13RrIn1h+pH+dArh3lNPD5JSAP+ifOkNhnB0=
@@ -91,12 +93,16 @@ github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.11/go.mod h1:tmUB6jakq5
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.12/go.mod h1:Afj/U8svX6sJ77Q+FPWMzabJ9QjbwP32YlopgKALUpg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18 h1:OmiwoVyLKEqqD5GvB683dbSqxiOfvx4U2lDZhG2Esc4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.18/go.mod h1:348MLhzV1GSlZSMusdwQpXKbhD7X2gbI/TxwAPKkYZQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22 h1:pE27/u2A7JlwICjOvONQDob8PToShRTkuiUE74ymVWg=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.22/go.mod h1:/vNv5Al0bpiF8YdX2Ov6Xy05VTiXsql94yUqJMYaj0w=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.0.2/go.mod h1:xT4XX6w5Sa3dhg50JrYyy3e4WPYo/+WjY/BXtqXVunU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.2.0/go.mod h1:BsCSJHx5DnDXIrOcqB8KN1/B+hXLG/bi4Y6Vjcx/x9E=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.5/go.mod h1:fV1AaS2gFc1tM0RCb015FJ0pvWVUfJZANzjwoO4YakM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.6/go.mod h1:FwpAKI+FBPIELJIdmQzlLtRe8LQSOreMcM2wBsPMvvc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.12 h1:5mvQDtNWtI6H56+E4LUnLWEmATMB7oEh+Z9RurtIuC0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.12/go.mod h1:ckaCVTEdGAxO6KwTGzgskxR1xM+iJW4lxMyDFVda2Fc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16 h1:L5LKGHHXOl4t7+5QZMTl38GIzSAq07XUTRtEquiHGMA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.16/go.mod h1:62dsXI0BqTIGomDl8Hpm33dv0OntGaVblri3ZRParVQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.4 h1:0NrDHIwS1LIR750ltj6ciiu4NZLpr9rgq8vHi/4QD4s=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.4/go.mod h1:R3sWUqPcfXSiF/LSFJhjyJmpg9uV6yP2yv3YZZjldVI=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.15.6 h1:GWrNZ3xtblr+J+oCYtJY67YPqR5nzObOaXWWKplDMag=
@@ -127,6 +133,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.18.5 h1:OR1FrOPrN
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.18.5/go.mod h1:v+U73J9xr5bwN0IYXIUlQnfWGVrcIGlY1wuq+vDsCyg=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.24.1 h1:VKo7a7XJbqzzELwaLzjpGm7uPPtO+ZKCs/oHonYk7lE=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.24.1/go.mod h1:MQeMcZxXxWr8VHc/8f8Hspg5D5dCm7wchXHYaiBntDw=
+github.com/aws/aws-sdk-go-v2/service/glue v1.31.0 h1:/Ap9LnJJzNGiI2zlXNqLoPxHWZoilETnAEEQe5eu6UU=
+github.com/aws/aws-sdk-go-v2/service/glue v1.31.0/go.mod h1:w+1dZ4Iz1ZwkATSlh9rKscmbQd7bOtNPN3z+ZYHyqjg=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.9.1 h1:qrd9evf91w8s7TIIvJakNzRJLW7HRiMDpQ9nmI7cOgo=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.9.1/go.mod h1:ckNYD0WIFojv8yOx5QiTp2tg64kTJdMFDPjR4y4mboY=
 github.com/aws/aws-sdk-go-v2/service/iam v1.18.5 h1:NUT8HreIoLAfPAP7eEYN8jwidvY+4TjZ86xqS/iGDQI=
@@ -160,6 +168,10 @@ github.com/aws/aws-sdk-go-v2/service/sagemaker v1.32.1 h1:nOjJ5PevzE1ymPIYnJk6X/
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.32.1/go.mod h1:nF9ZnJeXLYw8PPRAtsBbG3aY1P8c5bUH2zqA/IAzaks=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.13.0 h1:VKvs4yx3nrcyBJcj4iSy5UI/Awdsa0fbDKesiNwPuZY=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.13.0/go.mod h1:5Oibvfj4kc6CE70qamrlOU+KSO/JWANgxIVbesvSMCE=
+github.com/aws/aws-sdk-go-v2/service/sns v1.18.0 h1:lLluuhi5MhoJXkdbczuvA7sWZ0fUsVL6yw9VUkJW3X8=
+github.com/aws/aws-sdk-go-v2/service/sns v1.18.0/go.mod h1:eRg+KGyfKJDRMEkqKKRSQPPI4M410dmXV84G32KIILo=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.19.9 h1:8Ea02xXIVE+N/y5oirWpKvMzFw20jk7mVP1o6nGXzN8=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.19.9/go.mod h1:Zs7d4VbFN1P8i9PkoH2s5U7/tJVHYGctOn5ax296/CY=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.27.1 h1:w/HlW+NGK5EU5jf/qekDZ56kg9jhvP/1Egh3bMRTdgo=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.27.1/go.mod h1:Ej87mQA2lDTOyPL/ZCjoChhTCU/fwPKg5Em62pOIqVc=
 github.com/aws/aws-sdk-go-v2/service/sso v1.9.0 h1:1qLJeQGBmNQW3mBNzK2CFmrQNmoXWrscPqsrAaU1aTA=
@@ -172,6 +184,8 @@ github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnw
 github.com/aws/smithy-go v1.11.3/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.12.1 h1:yQRC55aXN/y1W10HgwHle01DRuV9Dpf31iGkotjt3Ag=
 github.com/aws/smithy-go v1.12.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.13.3 h1:l7LYxGuzK6/K+NzJ2mC+VvLUbae0sL3bXU//04MkmnA=
+github.com/aws/smithy-go v1.13.3/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
Adding in 3 services to the inventory function: Glue, SNS, & SQS

Glue Dev endpoints seemed to have a bug when using the NextToken input field, where looping over the available endpoints would continue infinitely: https://github.com/aws/aws-sdk-go-v2/blob/main/service/glue/api_op_ListDevEndpoints.go. For now, this PR just adds the current page of results.

Glue Jobs are added, which can have interesting data in each job's script. They can also be used for a PassRole privesc.

SNS Topics & SQS Queues can occasionally have policy misconfigurations. They frequently move data between services, so they are generally good to investigate as well.