### PR TITLE
Update to cloudfox-policy.json Sid

### DIFF
--- a/misc/aws/cloudfox-policy.json
+++ b/misc/aws/cloudfox-policy.json
@@ -67,7 +67,7 @@
             ],
             "Resource": "*",
             "Effect": "Allow",
-            "Sid": "AllowMoreReadForCloudFox-1.7.1"
+            "Sid": "AllowMoreReadForCloudFox171"
         }
     ]
 }


### PR DESCRIPTION
This was throwing errors due to the use of `-` and `.` characters, as per https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-error-unsupported-sid

#### Card

#### Details
