### PR TITLE
Small bug fixes and cleanup

### DIFF
--- a/aws/access-keys.go
+++ b/aws/access-keys.go
@@ -46,8 +46,10 @@ func (m *AccessKeysModule) PrintAccessKeys(filter string, outputFormat string, o
 		"module": m.output.CallingModule,
 	},
 	)
+
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Mapping user access keys for account: %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/access-keys.go
+++ b/aws/access-keys.go
@@ -48,7 +48,6 @@ func (m *AccessKeysModule) PrintAccessKeys(filter string, outputFormat string, o
 	)
 
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/access-keys.go
+++ b/aws/access-keys.go
@@ -83,7 +83,7 @@ func (m *AccessKeysModule) PrintAccessKeys(filter string, outputFormat string, o
 		//m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
 
-		m.writeLoot(outputDirectory, verbosity)
+		m.writeLoot(m.output.FilePath, verbosity)
 		fmt.Printf("[%s] %s access keys found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 	} else {
 		fmt.Printf("[%s] No  access keys found, skipping the creation of an output file.\n", cyan(m.output.CallingModule))
@@ -92,7 +92,7 @@ func (m *AccessKeysModule) PrintAccessKeys(filter string, outputFormat string, o
 }
 
 func (m *AccessKeysModule) writeLoot(outputDirectory string, verbosity int) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/buckets.go
+++ b/aws/buckets.go
@@ -52,7 +52,6 @@ func (m *BucketsModule) PrintBuckets(outputFormat string, outputDirectory string
 	})
 
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/buckets.go
+++ b/aws/buckets.go
@@ -50,8 +50,10 @@ func (m *BucketsModule) PrintBuckets(outputFormat string, outputDirectory string
 	m.modLog = utils.TxtLogger.WithFields(logrus.Fields{
 		"module": m.output.CallingModule,
 	})
+
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating buckets for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))
@@ -102,7 +104,7 @@ func (m *BucketsModule) PrintBuckets(outputFormat string, outputDirectory string
 		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		////m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
-		m.writeLoot(outputDirectory, verbosity, m.AWSProfile)
+		m.writeLoot(m.output.FilePath, verbosity, m.AWSProfile)
 		fmt.Printf("[%s] %s buckets found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 
 	} else {
@@ -135,7 +137,7 @@ func (m *BucketsModule) executeChecks(wg *sync.WaitGroup, semaphore chan struct{
 }
 
 func (m *BucketsModule) writeLoot(outputDirectory string, verbosity int, profile string) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -56,7 +56,8 @@ func (m *ECRModule) PrintECR(outputFormat string, outputDirectory string, verbos
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating container repositories for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -56,7 +56,6 @@ func (m *ECRModule) PrintECR(outputFormat string, outputDirectory string, verbos
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -122,7 +122,7 @@ func (m *ECRModule) PrintECR(outputFormat string, outputDirectory string, verbos
 		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		//m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
-		m.writeLoot(outputDirectory, verbosity)
+		m.writeLoot(m.output.FilePath, verbosity)
 		fmt.Printf("[%s] %s repositories found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 	} else {
 		fmt.Printf("[%s] No repositories found, skipping the creation of an output file.\n", cyan(m.output.CallingModule))
@@ -152,7 +152,7 @@ func (m *ECRModule) Receiver(receiver chan Repository, receiverDone chan bool) {
 }
 
 func (m *ECRModule) writeLoot(outputDirectory string, verbosity int) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/endpoints.go
+++ b/aws/endpoints.go
@@ -88,7 +88,8 @@ func (m *EndpointsModule) PrintEndpoints(outputFormat string, outputDirectory st
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating endpoints for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/endpoints.go
+++ b/aws/endpoints.go
@@ -169,7 +169,7 @@ func (m *EndpointsModule) PrintEndpoints(outputFormat string, outputDirectory st
 		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		//m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
-		m.writeLoot(outputDirectory, verbosity)
+		m.writeLoot(m.output.FilePath, verbosity)
 		fmt.Printf("[%s] %s endpoints found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 	} else {
 		fmt.Printf("[%s] No endpoints found, skipping the creation of an output file.\n", cyan(m.output.CallingModule))
@@ -260,7 +260,7 @@ func (m *EndpointsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore 
 }
 
 func (m *EndpointsModule) writeLoot(outputDirectory string, verbosity int) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/endpoints.go
+++ b/aws/endpoints.go
@@ -88,7 +88,6 @@ func (m *EndpointsModule) PrintEndpoints(outputFormat string, outputDirectory st
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/env-vars.go
+++ b/aws/env-vars.go
@@ -72,7 +72,8 @@ func (m *EnvsModule) PrintEnvs(outputFormat string, outputDirectory string, verb
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating environment variables in all regions for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/env-vars.go
+++ b/aws/env-vars.go
@@ -72,7 +72,6 @@ func (m *EnvsModule) PrintEnvs(outputFormat string, outputDirectory string, verb
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/filesystems.go
+++ b/aws/filesystems.go
@@ -63,7 +63,8 @@ func (m *FilesystemsModule) PrintFilesystems(outputFormat string, outputDirector
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	//populate region in the filesystems module struct
 	for i, region := range m.AWSRegions {

--- a/aws/filesystems.go
+++ b/aws/filesystems.go
@@ -137,7 +137,7 @@ func (m *FilesystemsModule) PrintFilesystems(outputFormat string, outputDirector
 		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		//m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
-		m.writeLoot(outputDirectory, verbosity)
+		m.writeLoot(m.output.FilePath, verbosity)
 		fmt.Printf("[%s] %s filesystems found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 
 	} else {
@@ -168,7 +168,7 @@ func (m *FilesystemsModule) executeChecks(r string, wg *sync.WaitGroup, semaphor
 }
 
 func (m *FilesystemsModule) writeLoot(outputDirectory string, verbosity int) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/filesystems.go
+++ b/aws/filesystems.go
@@ -63,7 +63,6 @@ func (m *FilesystemsModule) PrintFilesystems(outputFormat string, outputDirector
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	//populate region in the filesystems module struct

--- a/aws/iam-simulator.go
+++ b/aws/iam-simulator.go
@@ -85,9 +85,9 @@ func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, 
 	var pmapperOutFileName string
 
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
-	}
 
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
+	}
 	wg := new(sync.WaitGroup)
 	// Create a channel to signal the spinner aka task status goroutine to finish
 	spinnerDone := make(chan bool)

--- a/aws/iam-simulator.go
+++ b/aws/iam-simulator.go
@@ -125,7 +125,7 @@ func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, 
 			m.getIAMUsers(wg, actionList, resource, dataReceiver)
 			wg.Add(1)
 			m.getIAMRoles(wg, actionList, resource, dataReceiver)
-			pmapperOutFileName = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot", fmt.Sprintf("pmapper-output-%s.txt", action))
+			pmapperOutFileName = filepath.Join(m.output.FullFilename, "loot", fmt.Sprintf("pmapper-output-%s.txt", action))
 			pmapperCommands = append(pmapperCommands, fmt.Sprintf("pmapper --profile %s query \"who can do %s with %s\" | tee %s\n", m.AWSProfile, action, resource, pmapperOutFileName))
 		} else {
 			// Both --principal and --action are empty. Run in default mode!
@@ -133,7 +133,7 @@ func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, 
 			m.output.FullFilename = m.output.CallingModule
 			m.executeChecks(wg, resource, dataReceiver)
 			for _, action := range defaultActionNames {
-				pmapperOutFileName = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot", fmt.Sprintf("pmapper-output-%s.txt", action))
+				pmapperOutFileName = filepath.Join(m.output.FullFilename, "loot", fmt.Sprintf("pmapper-output-%s.txt", action))
 				pmapperCommands = append(pmapperCommands, fmt.Sprintf("pmapper --profile %s query \"who can do %s with %s\" | tee %s\n", m.AWSProfile, action, resource, pmapperOutFileName))
 			}
 
@@ -175,14 +175,14 @@ func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, 
 
 	}
 	if len(m.output.Body) > 0 {
-		//m.output.OutputSelector(outputFormat)
+		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.FullFilename, m.output.CallingModule)
 		fmt.Printf("[%s] We suggest running the pmapper commands in the loot file to get the same information but taking privesc paths into account.\n", cyan(m.output.CallingModule))
 		// fmt.Printf("[%s]\t\tpmapper --profile %s graph create\n", cyan(m.output.CallingModule), m.AWSProfile)
 		// for _, line := range pmapperCommands {
 		// 	fmt.Printf("[%s]\t\t%s", cyan(m.output.CallingModule), line)
 		// }
-		m.writeLoot(outputDirectory, verbosity, pmapperCommands)
+		m.writeLoot(m.output.FilePath, verbosity, pmapperCommands)
 
 	} else if principal != "" || action != "" {
 		fmt.Printf("[%s] No allowed permissions identified, skipping the creation of an output file.\n", cyan(m.output.CallingModule))
@@ -191,7 +191,7 @@ func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, 
 }
 
 func (m *IamSimulatorModule) writeLoot(outputDirectory string, verbosity int, pmapperCommands []string) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/iam-simulator.go
+++ b/aws/iam-simulator.go
@@ -85,7 +85,6 @@ func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, 
 	var pmapperOutFileName string
 
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	wg := new(sync.WaitGroup)

--- a/aws/instances.go
+++ b/aws/instances.go
@@ -59,7 +59,6 @@ func (m *InstancesModule) Instances(filter string, outputFormat string, outputDi
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	// regions, errtemp := m.EC2Client.DescribeRegions(

--- a/aws/instances.go
+++ b/aws/instances.go
@@ -170,6 +170,7 @@ func (m *InstancesModule) printInstancesUserDataAttributesOnly(outputFormat stri
 			}
 		}
 	}
+	// only create a file if if there is at least one instance AND at least one instance had user-data.
 	if (len(m.MappedInstances) > 0) && (userDataOut != "=============================================\n") {
 		if m.output.Verbosity > 1 {
 			fmt.Printf("%s", userDataOut)

--- a/aws/instances.go
+++ b/aws/instances.go
@@ -142,7 +142,6 @@ func (m *InstancesModule) printInstancesUserDataAttributesOnly(outputFormat stri
 
 	m.output.CallingModule = "instance-userdata"
 	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
-
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())
@@ -221,7 +220,7 @@ func (m *InstancesModule) printGeneralInstanceData(outputFormat string, outputDi
 		////m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(m.output.Verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
 
-		m.writeLoot(outputDirectory)
+		m.writeLoot(m.output.FilePath)
 		fmt.Printf("[%s] %s instances found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 
 	} else {
@@ -230,7 +229,7 @@ func (m *InstancesModule) printGeneralInstanceData(outputFormat string, outputDi
 }
 
 func (m *InstancesModule) writeLoot(outputDirectory string) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/instances.go
+++ b/aws/instances.go
@@ -59,9 +59,9 @@ func (m *InstancesModule) Instances(filter string, outputFormat string, outputDi
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
-	}
 
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
+	}
 	// regions, errtemp := m.EC2Client.DescribeRegions(
 	// 	context.TODO(),
 	// 	&ec2.DescribeRegionsInput{})
@@ -171,7 +171,7 @@ func (m *InstancesModule) printInstancesUserDataAttributesOnly(outputFormat stri
 			}
 		}
 	}
-	if len(m.MappedInstances) > 0 {
+	if (len(m.MappedInstances) > 0) && (userDataOut != "=============================================\n") {
 		if m.output.Verbosity > 1 {
 			fmt.Printf("%s", userDataOut)
 		}
@@ -181,6 +181,8 @@ func (m *InstancesModule) printInstancesUserDataAttributesOnly(outputFormat stri
 			m.CommandCounter.Error++
 		}
 		fmt.Printf("[%s] Loot written to [%s]\n", cyan(m.output.CallingModule), userDataFileName)
+	} else {
+		fmt.Printf("[%s] No user data found, skipping the creation of an output file\n", cyan(m.output.CallingModule))
 	}
 }
 

--- a/aws/inventory.go
+++ b/aws/inventory.go
@@ -111,7 +111,8 @@ func (m *Inventory2Module) PrintInventoryPerRegion(outputFormat string, outputDi
 	m.totalRegionCounts = map[string]int{}
 
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	//initialize servicemap and total

--- a/aws/inventory.go
+++ b/aws/inventory.go
@@ -111,7 +111,6 @@ func (m *Inventory2Module) PrintInventoryPerRegion(outputFormat string, outputDi
 	m.totalRegionCounts = map[string]int{}
 
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/outbound-assumed-roles.go
+++ b/aws/outbound-assumed-roles.go
@@ -122,9 +122,9 @@ func (m *OutboundAssumedRolesModule) PrintOutboundRoleTrusts(days int, outputFor
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
-	}
 
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
+	}
 	m.Days = days
 
 	fmt.Printf("[%s] Enumerating outbound assumed role entries in cloudtrail for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/outbound-assumed-roles.go
+++ b/aws/outbound-assumed-roles.go
@@ -122,7 +122,6 @@ func (m *OutboundAssumedRolesModule) PrintOutboundRoleTrusts(days int, outputFor
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	m.Days = days

--- a/aws/permissions.go
+++ b/aws/permissions.go
@@ -92,7 +92,6 @@ func (m *IamPermissionsModule) PrintIamPermissions(outputFormat string, outputDi
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)

--- a/aws/permissions.go
+++ b/aws/permissions.go
@@ -92,7 +92,8 @@ func (m *IamPermissionsModule) PrintIamPermissions(outputFormat string, outputDi
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 	fmt.Printf("[%s] Enumerating IAM permissions for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/principals.go
+++ b/aws/principals.go
@@ -72,7 +72,6 @@ func (m *IamPrincipalsModule) PrintIamPrincipals(outputFormat string, outputDire
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/principals.go
+++ b/aws/principals.go
@@ -72,7 +72,8 @@ func (m *IamPrincipalsModule) PrintIamPrincipals(outputFormat string, outputDire
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating IAM Users and Roles for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/ram.go
+++ b/aws/ram.go
@@ -49,7 +49,8 @@ func (m *RAMModule) PrintRAM(outputFormat string, outputDirectory string, verbos
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating shared resources for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/ram.go
+++ b/aws/ram.go
@@ -49,7 +49,6 @@ func (m *RAMModule) PrintRAM(outputFormat string, outputDirectory string, verbos
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/role-trusts.go
+++ b/aws/role-trusts.go
@@ -44,7 +44,8 @@ func (m *RoleTrustsModule) PrintRoleTrusts(outputFormat string, outputDirectory 
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	fmt.Printf("[%s] Enumerating role trusts for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))
 

--- a/aws/role-trusts.go
+++ b/aws/role-trusts.go
@@ -44,7 +44,6 @@ func (m *RoleTrustsModule) PrintRoleTrusts(outputFormat string, outputDirectory 
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 	fmt.Printf("[%s] Enumerating role trusts for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/route53.go
+++ b/aws/route53.go
@@ -89,7 +89,7 @@ func (m *Route53Module) PrintRoute53(outputFormat string, outputDirectory string
 		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		//m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
-		m.writeLoot(outputDirectory, verbosity)
+		m.writeLoot(m.output.FilePath, verbosity)
 		fmt.Printf("[%s] %s DNS records found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 
 	} else {
@@ -99,7 +99,7 @@ func (m *Route53Module) PrintRoute53(outputFormat string, outputDirectory string
 }
 
 func (m *Route53Module) writeLoot(outputDirectory string, verbosity int) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/aws/route53.go
+++ b/aws/route53.go
@@ -55,7 +55,8 @@ func (m *Route53Module) PrintRoute53(outputFormat string, outputDirectory string
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating Route53 for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/route53.go
+++ b/aws/route53.go
@@ -55,7 +55,6 @@ func (m *Route53Module) PrintRoute53(outputFormat string, outputDirectory string
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -53,7 +53,6 @@ func (m *SecretsModule) PrintSecrets(outputFormat string, outputDirectory string
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-
 		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 

--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -53,7 +53,8 @@ func (m *SecretsModule) PrintSecrets(outputFormat string, outputDirectory string
 		"module": m.output.CallingModule,
 	})
 	if m.AWSProfile == "" {
-		m.AWSProfile = fmt.Sprintf("%s-%s", aws.ToString(m.Caller.Account), aws.ToString(m.Caller.UserId))
+
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
 	}
 
 	fmt.Printf("[%s] Enumerating secrets for account %s.\n", cyan(m.output.CallingModule), aws.ToString(m.Caller.Account))

--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -115,7 +115,7 @@ func (m *SecretsModule) PrintSecrets(outputFormat string, outputDirectory string
 		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
 		//m.output.OutputSelector(outputFormat)
 		utils.OutputSelector(m.output.Verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
-		m.writeLoot(outputDirectory, verbosity)
+		m.writeLoot(m.output.FilePath, verbosity)
 		fmt.Printf("[%s] %s secrets found.\n", cyan(m.output.CallingModule), strconv.Itoa(len(m.output.Body)))
 
 	} else {
@@ -151,7 +151,7 @@ func (m *SecretsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore ch
 }
 
 func (m *SecretsModule) writeLoot(outputDirectory string, verbosity int) {
-	path := filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile, "loot")
+	path := filepath.Join(outputDirectory, "loot")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		m.modLog.Error(err.Error())

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -168,34 +168,36 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.Inventory2Module{
-				EC2Client:            ec2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				ECSClient:            ecs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				EKSClient:            eks.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				S3Client:             s3.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				LambdaClient:         lambda.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				CloudFormationClient: cloudformation.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				SecretsManagerClient: secretsmanager.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				SSMClient:            ssm.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				RDSClient:            rds.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				APIGatewayv2Client:   apigatewayv2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				ELBClient:            elasticloadbalancing.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				ELBv2Client:          elasticloadbalancingv2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				IAMClient:            iam.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				MQClient:             mq.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				OpenSearchClient:     opensearch.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				GrafanaClient:        grafana.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				APIGatewayClient:     apigateway.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				RedshiftClient:       redshift.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				CloudfrontClient:     cloudfront.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				AppRunnerClient:      apprunner.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				LightsailClient:      lightsail.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				GlueClient:           glue.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				SNSClient:            sns.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				SQSClient:            sqs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				DynamoDBClient:       dynamodb.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				EC2Client:            ec2.NewFromConfig(AWSConfig),
+				ECSClient:            ecs.NewFromConfig(AWSConfig),
+				EKSClient:            eks.NewFromConfig(AWSConfig),
+				S3Client:             s3.NewFromConfig(AWSConfig),
+				LambdaClient:         lambda.NewFromConfig(AWSConfig),
+				CloudFormationClient: cloudformation.NewFromConfig(AWSConfig),
+				SecretsManagerClient: secretsmanager.NewFromConfig(AWSConfig),
+				SSMClient:            ssm.NewFromConfig(AWSConfig),
+				RDSClient:            rds.NewFromConfig(AWSConfig),
+				APIGatewayv2Client:   apigatewayv2.NewFromConfig(AWSConfig),
+				ELBClient:            elasticloadbalancing.NewFromConfig(AWSConfig),
+				ELBv2Client:          elasticloadbalancingv2.NewFromConfig(AWSConfig),
+				IAMClient:            iam.NewFromConfig(AWSConfig),
+				MQClient:             mq.NewFromConfig(AWSConfig),
+				OpenSearchClient:     opensearch.NewFromConfig(AWSConfig),
+				GrafanaClient:        grafana.NewFromConfig(AWSConfig),
+				APIGatewayClient:     apigateway.NewFromConfig(AWSConfig),
+				RedshiftClient:       redshift.NewFromConfig(AWSConfig),
+				CloudfrontClient:     cloudfront.NewFromConfig(AWSConfig),
+				AppRunnerClient:      apprunner.NewFromConfig(AWSConfig),
+				LightsailClient:      lightsail.NewFromConfig(AWSConfig),
+				GlueClient:           glue.NewFromConfig(AWSConfig),
+				SNSClient:            sns.NewFromConfig(AWSConfig),
+				SQSClient:            sqs.NewFromConfig(AWSConfig),
+				DynamoDBClient:       dynamodb.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -215,24 +217,26 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.EndpointsModule{
-				EKSClient:          eks.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				LambdaClient:       lambda.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				MQClient:           mq.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				OpenSearchClient:   opensearch.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				GrafanaClient:      grafana.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				ELBClient:          elasticloadbalancing.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				APIGatewayClient:   apigateway.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				ELBv2Client:        elasticloadbalancingv2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				APIGatewayv2Client: apigatewayv2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				RDSClient:          rds.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				RedshiftClient:     redshift.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				S3Client:           s3.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				CloudfrontClient:   cloudfront.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				AppRunnerClient:    apprunner.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				LightsailClient:    lightsail.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				EKSClient:          eks.NewFromConfig(AWSConfig),
+				LambdaClient:       lambda.NewFromConfig(AWSConfig),
+				MQClient:           mq.NewFromConfig(AWSConfig),
+				OpenSearchClient:   opensearch.NewFromConfig(AWSConfig),
+				GrafanaClient:      grafana.NewFromConfig(AWSConfig),
+				ELBClient:          elasticloadbalancing.NewFromConfig(AWSConfig),
+				APIGatewayClient:   apigateway.NewFromConfig(AWSConfig),
+				ELBv2Client:        elasticloadbalancingv2.NewFromConfig(AWSConfig),
+				APIGatewayv2Client: apigatewayv2.NewFromConfig(AWSConfig),
+				RDSClient:          rds.NewFromConfig(AWSConfig),
+				RedshiftClient:     redshift.NewFromConfig(AWSConfig),
+				S3Client:           s3.NewFromConfig(AWSConfig),
+				CloudfrontClient:   cloudfront.NewFromConfig(AWSConfig),
+				AppRunnerClient:    apprunner.NewFromConfig(AWSConfig),
+				LightsailClient:    lightsail.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -252,11 +256,13 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.SecretsModule{
-				SecretsManagerClient: secretsmanager.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				SSMClient:            ssm.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				SecretsManagerClient: secretsmanager.NewFromConfig(AWSConfig),
+				SSMClient:            ssm.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -276,10 +282,12 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.Route53Module{
-				Route53Client: route53.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				Route53Client: route53.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -299,10 +307,12 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.ECRModule{
-				ECRClient: ecr.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				ECRClient: ecr.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -322,10 +332,12 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.OutboundAssumedRolesModule{
-				CloudTrailClient: cloudtrail.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				CloudTrailClient: cloudtrail.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -345,17 +357,19 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.EnvsModule{
 
-				Caller:          utils.AWSWhoami(AWSProfile),
+				Caller:          Caller,
 				AWSRegions:      AWSRegions,
 				AWSProfile:      AWSProfile,
 				Goroutines:      Goroutines,
-				ECSClient:       ecs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				AppRunnerClient: apprunner.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				LambdaClient:    lambda.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				LightsailClient: lightsail.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				SagemakerClient: sagemaker.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				ECSClient:       ecs.NewFromConfig(AWSConfig),
+				AppRunnerClient: apprunner.NewFromConfig(AWSConfig),
+				LambdaClient:    lambda.NewFromConfig(AWSConfig),
+				LightsailClient: lightsail.NewFromConfig(AWSConfig),
+				SagemakerClient: sagemaker.NewFromConfig(AWSConfig),
 			}
 			m.PrintEnvs(AWSOutputFormat, AWSOutputDirectory, Verbosity)
 		},
@@ -372,9 +386,11 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.IamPrincipalsModule{
-				IAMClient:  iam.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				Caller:     utils.AWSWhoami(AWSProfile),
+				IAMClient:  iam.NewFromConfig(AWSConfig),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
@@ -395,9 +411,11 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.IamPermissionsModule{
-				IAMClient:  iam.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				Caller:     utils.AWSWhoami(AWSProfile),
+				IAMClient:  iam.NewFromConfig(AWSConfig),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
@@ -419,10 +437,12 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			m := aws.IamSimulatorModule{
-				IAMClient: iam.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				IAMClient: iam.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
@@ -441,11 +461,13 @@ var (
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 			filesystems := aws.FilesystemsModule{
-				EFSClient: efs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				FSxClient: fsx.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
+				EFSClient: efs.NewFromConfig(AWSConfig),
+				FSxClient: fsx.NewFromConfig(AWSConfig),
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 				AWSRegions: AWSRegions,
@@ -485,40 +507,43 @@ var (
 			os.Args[0] + " aws all-checks --profile readonly_profile",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			var caller = utils.AWSWhoami(AWSProfile)
+
 			fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			var AWSConfig = utils.AWSConfigFileLoader(AWSProfile)
+			var Caller = utils.AWSWhoami(AWSProfile)
 
-			ec2Client := ec2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			eksClient := eks.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			s3Client := s3.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			lambdaClient := lambda.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			cloudFormationClient := cloudformation.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			secretsManagerClient := secretsmanager.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			rdsClient := rds.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			apiGatewayv2Client := apigatewayv2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			apiGatewayClient := apigateway.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			elbClient := elasticloadbalancing.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			elbv2Client := elasticloadbalancingv2.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			iamClient := iam.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			mqClient := mq.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			openSearchClient := opensearch.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			grafanaClient := grafana.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			redshiftClient := redshift.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			cloudfrontClient := cloudfront.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			appRunnerClient := apprunner.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			lightsailClient := lightsail.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			route53Client := route53.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			efsClient := efs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			fsxClient := fsx.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			ecsClient := ecs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			sagemakerClient := sagemaker.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			ecrClient := ecr.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			ssmClient := ssm.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			glueClient := glue.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			snsClient := sns.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			sqsClient := sqs.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
-			dynamodbClient := dynamodb.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile))
+			ec2Client := ec2.NewFromConfig(AWSConfig)
+			eksClient := eks.NewFromConfig(AWSConfig)
+			s3Client := s3.NewFromConfig(AWSConfig)
+			lambdaClient := lambda.NewFromConfig(AWSConfig)
+			cloudFormationClient := cloudformation.NewFromConfig(AWSConfig)
+			secretsManagerClient := secretsmanager.NewFromConfig(AWSConfig)
+			rdsClient := rds.NewFromConfig(AWSConfig)
+			apiGatewayv2Client := apigatewayv2.NewFromConfig(AWSConfig)
+			apiGatewayClient := apigateway.NewFromConfig(AWSConfig)
+			elbClient := elasticloadbalancing.NewFromConfig(AWSConfig)
+			elbv2Client := elasticloadbalancingv2.NewFromConfig(AWSConfig)
+			iamClient := iam.NewFromConfig(AWSConfig)
+			mqClient := mq.NewFromConfig(AWSConfig)
+			openSearchClient := opensearch.NewFromConfig(AWSConfig)
+			grafanaClient := grafana.NewFromConfig(AWSConfig)
+			redshiftClient := redshift.NewFromConfig(AWSConfig)
+			cloudfrontClient := cloudfront.NewFromConfig(AWSConfig)
+			appRunnerClient := apprunner.NewFromConfig(AWSConfig)
+			lightsailClient := lightsail.NewFromConfig(AWSConfig)
+			route53Client := route53.NewFromConfig(AWSConfig)
+			efsClient := efs.NewFromConfig(AWSConfig)
+			fsxClient := fsx.NewFromConfig(AWSConfig)
+			ecsClient := ecs.NewFromConfig(AWSConfig)
+			sagemakerClient := sagemaker.NewFromConfig(AWSConfig)
+			ecrClient := ecr.NewFromConfig(AWSConfig)
+			ssmClient := ssm.NewFromConfig(AWSConfig)
+			glueClient := glue.NewFromConfig(AWSConfig)
+			snsClient := sns.NewFromConfig(AWSConfig)
+			sqsClient := sqs.NewFromConfig(AWSConfig)
+			dynamodbClient := dynamodb.NewFromConfig(AWSConfig)
 
 			fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("Getting a lay of the land, aka \"What regions is this account using?\""))
 			inventory2 := aws.Inventory2Module{
@@ -548,7 +573,7 @@ var (
 				SQSClient:            sqsClient,
 				DynamoDBClient:       dynamodbClient,
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -560,7 +585,7 @@ var (
 
 			instances := aws.InstancesModule{
 				EC2Client:  ec2Client,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 
 				UserDataAttributesOnly: false,
@@ -570,7 +595,7 @@ var (
 			route53 := aws.Route53Module{
 				Route53Client: route53Client,
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -580,7 +605,7 @@ var (
 			filesystems := aws.FilesystemsModule{
 				EFSClient:  efsClient,
 				FSxClient:  fsxClient,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 				AWSRegions: AWSRegions,
@@ -605,7 +630,7 @@ var (
 				AppRunnerClient:    appRunnerClient,
 				LightsailClient:    lightsailClient,
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -616,9 +641,10 @@ var (
 			fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("Looking for secrets hidden between the seat cushions."))
 
 			ec2UserData := aws.InstancesModule{
-				EC2Client:              ec2Client,
-				Caller:                 utils.AWSWhoami(AWSProfile),
-				AWSRegions:             AWSRegions,
+				EC2Client:  ec2Client,
+				Caller:     Caller,
+				AWSRegions: AWSRegions,
+
 				UserDataAttributesOnly: true,
 				AWSProfile:             AWSProfile,
 				Goroutines:             Goroutines,
@@ -626,7 +652,7 @@ var (
 			ec2UserData.Instances(InstancesFilter, AWSOutputFormat, AWSOutputDirectory, Verbosity)
 			envsMod := aws.EnvsModule{
 
-				Caller:          utils.AWSWhoami(AWSProfile),
+				Caller:          Caller,
 				AWSRegions:      AWSRegions,
 				AWSProfile:      AWSProfile,
 				Goroutines:      Goroutines,
@@ -644,7 +670,7 @@ var (
 
 			buckets := aws.BucketsModule{
 				S3Client:   s3Client,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
@@ -652,7 +678,7 @@ var (
 
 			ecr := aws.ECRModule{
 				ECRClient:  ecrClient,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -663,7 +689,7 @@ var (
 				SecretsManagerClient: secretsManagerClient,
 				SSMClient:            ssmClient,
 
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSRegions: AWSRegions,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
@@ -674,35 +700,35 @@ var (
 			fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("IAM is complicated. Complicated usually means misconfigurations. You'll want to pay attention here."))
 			principals := aws.IamPrincipalsModule{
 				IAMClient:  iamClient,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
 			principals.PrintIamPrincipals(AWSOutputFormat, AWSOutputDirectory, Verbosity)
 			permissions := aws.IamPermissionsModule{
 				IAMClient:  iamClient,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
 			permissions.PrintIamPermissions(AWSOutputFormat, AWSOutputDirectory, Verbosity, PermissionsPrincipal)
 			accessKeys := aws.AccessKeysModule{
-				IAMClient:  iam.NewFromConfig(utils.AWSConfigFileLoader(AWSProfile)),
-				Caller:     utils.AWSWhoami(AWSProfile),
+				IAMClient:  iam.NewFromConfig(AWSConfig),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
 			accessKeys.PrintAccessKeys(AccessKeysFilter, AWSOutputFormat, AWSOutputDirectory, Verbosity)
 			inboundRoleTrusts := aws.RoleTrustsModule{
 				IAMClient:  iamClient,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}
 			inboundRoleTrusts.PrintRoleTrusts(AWSOutputFormat, AWSOutputDirectory, Verbosity)
 			iamSimulator := aws.IamSimulatorModule{
 				IAMClient:  iamClient,
-				Caller:     utils.AWSWhoami(AWSProfile),
+				Caller:     Caller,
 				AWSProfile: AWSProfile,
 				Goroutines: Goroutines,
 			}

--- a/utils/aws.go
+++ b/utils/aws.go
@@ -103,19 +103,18 @@ func txtLogger() *logrus.Logger {
 	return txtLogger
 }
 
-func removeBadPathChars(_String *string) string {
-	var _path string
-	var bannedPathChars *regexp.Regexp
-	bannedPathChars = regexp.MustCompile(`[<>:"'|?*]`)
-	_path = bannedPathChars.ReplaceAllString(aws.ToString(_String), "_")
+func removeBadPathChars(receivedPath *string) string {
+	var path string
+	var bannedPathChars *regexp.Regexp = regexp.MustCompile(`[<>:"'|?*]`)
+	path = bannedPathChars.ReplaceAllString(aws.ToString(receivedPath), "_")
 
-	return _path
+	return path
 
 }
 
 func BuildAWSPath(Caller sts.GetCallerIdentityOutput) string {
-	var _CallerAccount = removeBadPathChars(Caller.Account)
-	var _CallerUserID = removeBadPathChars(Caller.UserId)
+	var callerAccount = removeBadPathChars(Caller.Account)
+	var callerUserID = removeBadPathChars(Caller.UserId)
 
-	return fmt.Sprintf("%s-%s", _CallerAccount, _CallerUserID)
+	return fmt.Sprintf("%s-%s", callerAccount, callerUserID)
 }

--- a/utils/aws.go
+++ b/utils/aws.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
@@ -42,10 +43,8 @@ func AWSConfigFileLoader(AWSProfile string) aws.Config {
 }
 
 func AWSWhoami(awsProfile string) sts.GetCallerIdentityOutput {
-
 	// Connects to STS and checks caller identity. Same as running "aws sts get-caller-identity"
 	//fmt.Printf("[%s] Retrieving caller's identity\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)))
-
 	STSService := sts.NewFromConfig(AWSConfigFileLoader(awsProfile))
 	CallerIdentity, err := STSService.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
 	if err != nil {
@@ -102,4 +101,21 @@ func txtLogger() *logrus.Logger {
 	//txtLogger.SetReportCaller(true)
 
 	return txtLogger
+}
+
+func removeBadPathChars(_String *string) string {
+	var _path string
+	var bannedPathChars *regexp.Regexp
+	bannedPathChars = regexp.MustCompile(`[<>:"'|?*]`)
+	_path = bannedPathChars.ReplaceAllString(aws.ToString(_String), "_")
+
+	return _path
+
+}
+
+func BuildAWSPath(Caller sts.GetCallerIdentityOutput) string {
+	var _CallerAccount = removeBadPathChars(Caller.Account)
+	var _CallerUserID = removeBadPathChars(Caller.UserId)
+
+	return fmt.Sprintf("%s-%s", _CallerAccount, _CallerUserID)
 }


### PR DESCRIPTION
### Details

- Created `removeBadPathChars` in `utils.aws` to clean any characters that would prevent a file from being written to the operating system
  - To fix a bug where an error occurred when the `Caller.UserID` contained illegal characters, such as `:`
- Created `BuildAWSPath` in `utils.aws`, which calls `removeBadPathChars` , and is called from each `aws` module to set `m.AWSProfile` by cleaning then concatenating the `Caller.Account` and `Caller.UserID`, returning a string
- Modified all `Command` based functions in `cli.aws` to:
  - Load the config once with AWSConfigFileLoader, then pass that value to each client created in the command
  - Limit additional STS calls by running `AWSWhoami` once after `PreRun` and passing it where needed. 
- Fixed a bug in `aws.instances.printInstancesUserDataAttributesOnly` where, when reporting User Data from instances, a file was being written when no User Data was present; now gives standard notice no data was found
- Minor cleanups of code to homogenize