### PR TITLE
small bugfix from env-vars command

### DIFF
--- a/cli/aws.go
+++ b/cli/aws.go
@@ -480,6 +480,7 @@ var (
 					Caller:          *caller,
 					AWSRegions:      AWSRegions,
 					AWSProfile:      profile,
+					Goroutines:      Goroutines,
 					ECSClient:       ecs.NewFromConfig(AWSConfig),
 					AppRunnerClient: apprunner.NewFromConfig(AWSConfig),
 					LambdaClient:    lambda.NewFromConfig(AWSConfig),


### PR DESCRIPTION
#### Card

Issue: #13

#### Details

The `Goroutines` argument is required for `aws.EnvsModule`, but was not passed.

Fixed to pass `Goroutines` argument to `aws.EnvsModule`.