### PR TITLE
add code for the ecs-tasks and elastic-network-interfaces commands

### DIFF
--- a/aws/ecs-tasks.go
+++ b/aws/ecs-tasks.go
@@ -20,8 +20,12 @@ import (
 )
 
 type ECSTasksModule struct {
-	ECSClient *ecs.Client
-	EC2Client *ec2.Client
+	//ECSClient           *ecs.Client
+	DescribeTasksClient ecs.DescribeTasksAPIClient
+	ListTasksClient     ecs.ListTasksAPIClient
+	ListClustersClient  ecs.ListClustersAPIClient
+	//EC2Client                       *ec2.Client
+	DescribeNetworkInterfacesClient ec2.DescribeNetworkInterfacesAPIClient
 
 	Caller       sts.GetCallerIdentityOutput
 	AWSRegions   []string
@@ -183,7 +187,7 @@ func (m *ECSTasksModule) getListClusters(region string, dataReceiver chan Mapped
 
 	var PaginationControl *string
 	for {
-		ListClusters, err := m.ECSClient.ListClusters(
+		ListClusters, err := m.ListClustersClient.ListClusters(
 			context.TODO(),
 			&(ecs.ListClustersInput{
 				NextToken: PaginationControl,
@@ -216,7 +220,7 @@ func (m *ECSTasksModule) getListTasks(clusterARN string, region string, dataRece
 	var PaginationControl *string
 	for {
 
-		ListTasks, err := m.ECSClient.ListTasks(
+		ListTasks, err := m.ListTasksClient.ListTasks(
 			context.TODO(),
 			&(ecs.ListTasksInput{
 				Cluster:   aws.String(clusterARN),
@@ -257,7 +261,7 @@ func (m *ECSTasksModule) loadTasksData(clusterARN string, taskARNs []string, reg
 		return
 	}
 
-	DescribeTasks, err := m.ECSClient.DescribeTasks(
+	DescribeTasks, err := m.DescribeTasksClient.DescribeTasks(
 		context.TODO(),
 		&(ecs.DescribeTasksInput{
 			Cluster: aws.String(clusterARN),
@@ -336,8 +340,7 @@ func (m *ECSTasksModule) loadPublicIPs(eniIDs []string, region string) (map[stri
 	if len(eniIDs) == 0 {
 		return eniPublicIPs, nil
 	}
-
-	DescribeNetworkInterfaces, err := m.EC2Client.DescribeNetworkInterfaces(
+	DescribeNetworkInterfaces, err := m.DescribeNetworkInterfacesClient.DescribeNetworkInterfaces(
 		context.TODO(),
 		&(ec2.DescribeNetworkInterfacesInput{
 			NetworkInterfaceIds: eniIDs,

--- a/aws/ecs-tasks.go
+++ b/aws/ecs-tasks.go
@@ -1,0 +1,410 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/BishopFox/cloudfox/console"
+	"github.com/BishopFox/cloudfox/utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/sirupsen/logrus"
+)
+
+type ECSTasksModule struct {
+	ECSClient *ecs.Client
+	EC2Client *ec2.Client
+
+	Caller       sts.GetCallerIdentityOutput
+	AWSRegions   []string
+	OutputFormat string
+	AWSProfile   string
+
+	MappedECSTasks []MappedECSTask
+	CommandCounter console.CommandCounter
+
+	output utils.OutputData2
+	modLog *logrus.Entry
+}
+
+type MappedECSTask struct {
+	Cluster        string
+	TaskDefinition string
+	LaunchType     string
+	ID             string
+	ExternalIP     string
+	PrivateIP      string
+}
+
+func (m *ECSTasksModule) ECSTasks(outputFormat string, outputDirectory string, verbosity int) {
+	m.output.Verbosity = verbosity
+	m.output.Directory = outputDirectory
+	m.output.CallingModule = "ecs-tasks"
+	m.modLog = utils.TxtLog.WithFields(logrus.Fields{
+		"module": m.output.CallingModule,
+	})
+	if m.AWSProfile == "" {
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
+	}
+
+	fmt.Printf("[%s][%s] Enumerating ECS tasks in all regions for account %s\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), aws.ToString(m.Caller.Account))
+
+	wg := new(sync.WaitGroup)
+
+	spinnerDone := make(chan bool)
+	go console.SpinUntil(m.output.CallingModule, &m.CommandCounter, spinnerDone, "tasks")
+
+	dataReceiver := make(chan MappedECSTask)
+
+	receiverDone := make(chan bool)
+	go m.Receiver(dataReceiver, receiverDone)
+	for _, region := range m.AWSRegions {
+		wg.Add(1)
+		m.CommandCounter.Pending++
+		go m.executeChecks(region, wg, dataReceiver)
+
+	}
+
+	wg.Wait()
+	spinnerDone <- true
+	<-spinnerDone
+	receiverDone <- true
+	<-receiverDone
+
+	m.printECSTaskData(outputFormat, outputDirectory, dataReceiver)
+
+}
+
+func (m *ECSTasksModule) Receiver(receiver chan MappedECSTask, receiverDone chan bool) {
+	defer close(receiverDone)
+	for {
+		select {
+		case data := <-receiver:
+			m.MappedECSTasks = append(m.MappedECSTasks, data)
+		case <-receiverDone:
+			receiverDone <- true
+			return
+		}
+	}
+}
+
+func (m *ECSTasksModule) printECSTaskData(outputFormat string, outputDirectory string, dataReceiver chan MappedECSTask) {
+	m.output.Headers = []string{
+		"Cluster",
+		"TaskDefinition",
+		"LaunchType",
+		"ID",
+		"External IP",
+		"Internal IP",
+	}
+
+	for _, ecsTask := range m.MappedECSTasks {
+		m.output.Body = append(
+			m.output.Body,
+			[]string{
+				ecsTask.Cluster,
+				ecsTask.TaskDefinition,
+				ecsTask.LaunchType,
+				ecsTask.ID,
+				ecsTask.ExternalIP,
+				ecsTask.PrivateIP,
+			},
+		)
+	}
+	if len(m.output.Body) > 0 {
+		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
+		utils.OutputSelector(m.output.Verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
+
+		m.writeLoot(m.output.FilePath)
+		fmt.Printf("[%s][%s] %s ECS tasks found.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), strconv.Itoa(len(m.output.Body)))
+
+	} else {
+		fmt.Printf("[%s][%s] No ECS tasks found, skipping the creation of an output file.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile))
+	}
+}
+
+func (m *ECSTasksModule) writeLoot(outputDirectory string) {
+	path := filepath.Join(outputDirectory, "loot")
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+	}
+	privateIPsFilename := filepath.Join(path, "ecs-tasks-PrivateIPs.txt")
+	publicIPsFilename := filepath.Join(path, "ecs-tasks-PublicIPs.txt")
+
+	var publicIPs string
+	var privateIPs string
+
+	for _, task := range m.MappedECSTasks {
+		if task.ExternalIP != "NoExternalIP" {
+			publicIPs = publicIPs + fmt.Sprintln(task.ExternalIP)
+		}
+		if task.PrivateIP != "" {
+			privateIPs = privateIPs + fmt.Sprintln(task.PrivateIP)
+		}
+
+	}
+	err = os.WriteFile(privateIPsFilename, []byte(privateIPs), 0644)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+	}
+	err = os.WriteFile(publicIPsFilename, []byte(publicIPs), 0644)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+	}
+
+	fmt.Printf("[%s][%s] Loot written to [%s]\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), privateIPsFilename)
+	fmt.Printf("[%s][%s] Loot written to [%s]\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), publicIPsFilename)
+
+}
+
+func (m *ECSTasksModule) executeChecks(r string, wg *sync.WaitGroup, dataReceiver chan MappedECSTask) {
+	defer wg.Done()
+	m.CommandCounter.Total++
+	m.CommandCounter.Pending--
+	m.CommandCounter.Executing++
+	m.getListClusters(r, dataReceiver)
+	m.CommandCounter.Executing--
+	m.CommandCounter.Complete++
+}
+
+func (m *ECSTasksModule) getListClusters(region string, dataReceiver chan MappedECSTask) {
+
+	var PaginationControl *string
+	for {
+		ListClusters, err := m.ECSClient.ListClusters(
+			context.TODO(),
+			&(ecs.ListClustersInput{
+				NextToken: PaginationControl,
+			}),
+			func(o *ecs.Options) {
+				o.Region = region
+			},
+		)
+		if err != nil {
+			m.modLog.Error(err.Error())
+			m.CommandCounter.Error++
+			break
+		}
+
+		for _, clusterARN := range ListClusters.ClusterArns {
+			m.getListTasks(clusterARN, region, dataReceiver)
+		}
+
+		if ListClusters.NextToken != nil {
+			PaginationControl = ListClusters.NextToken
+		} else {
+			PaginationControl = nil
+			break
+		}
+
+	}
+}
+
+func (m *ECSTasksModule) getListTasks(clusterARN string, region string, dataReceiver chan MappedECSTask) {
+	var PaginationControl *string
+	for {
+
+		ListTasks, err := m.ECSClient.ListTasks(
+			context.TODO(),
+			&(ecs.ListTasksInput{
+				Cluster:   aws.String(clusterARN),
+				NextToken: PaginationControl,
+			}),
+			func(o *ecs.Options) {
+				o.Region = region
+			},
+		)
+		if err != nil {
+			m.modLog.Error(err.Error())
+			m.CommandCounter.Error++
+			break
+		}
+
+		batchSize := 100 // maximum value: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html#API_DescribeTasks_RequestSyntax
+		for i := 0; i < len(ListTasks.TaskArns); i += batchSize {
+			j := i + batchSize
+			if j > len(ListTasks.TaskArns) {
+				j = len(ListTasks.TaskArns)
+			}
+
+			m.loadTasksData(clusterARN, ListTasks.TaskArns[i:j], region, dataReceiver)
+		}
+
+		if ListTasks.NextToken != nil {
+			PaginationControl = ListTasks.NextToken
+		} else {
+			PaginationControl = nil
+			break
+		}
+
+	}
+}
+
+func (m *ECSTasksModule) loadTasksData(clusterARN string, taskARNs []string, region string, dataReceiver chan MappedECSTask) {
+	if len(taskARNs) == 0 {
+		return
+	}
+
+	DescribeTasks, err := m.ECSClient.DescribeTasks(
+		context.TODO(),
+		&(ecs.DescribeTasksInput{
+			Cluster: aws.String(clusterARN),
+			Tasks:   taskARNs,
+		}),
+		func(o *ecs.Options) {
+			o.Region = region
+		},
+	)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+		return
+	}
+
+	eniIDs := []string{}
+	for _, task := range DescribeTasks.Tasks {
+		eniID := getElasticNetworkInterfaceIDOfECSTask(task)
+		if eniID != "" {
+			eniIDs = append(eniIDs, eniID)
+		}
+	}
+	publicIPs, err := m.loadPublicIPs(eniIDs, region)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+		return
+	}
+
+	for _, task := range DescribeTasks.Tasks {
+		mappedTask := MappedECSTask{
+			Cluster:        getNameFromARN(clusterARN),
+			TaskDefinition: getNameFromARN(aws.ToString(task.TaskDefinitionArn)),
+			LaunchType:     string(task.LaunchType),
+			ID:             getIDFromECSTask(aws.ToString(task.TaskArn)),
+			PrivateIP:      getPrivateIPv4AddressFromECSTask(task),
+		}
+
+		eniID := getElasticNetworkInterfaceIDOfECSTask(task)
+		if eniID != "" {
+			mappedTask.ExternalIP = publicIPs[eniID]
+		}
+
+		dataReceiver <- mappedTask
+	}
+}
+
+func (m *ECSTasksModule) loadAllPublicIPs(eniIDs []string, region string) (map[string]string, error) {
+	eniPublicIPs := make(map[string]string)
+
+	batchSize := 1000 // seems to be maximum value: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html
+	for i := 0; i < len(eniIDs); i += batchSize {
+		j := i + batchSize
+		if j > len(eniIDs) {
+			j = len(eniIDs)
+		}
+
+		publicIPs, err := m.loadPublicIPs(eniIDs[i:j], region)
+		if err != nil {
+			m.modLog.Error(err.Error())
+			m.CommandCounter.Error++
+			return nil, fmt.Errorf("getting elastic network interfaces: %s", err)
+		}
+
+		for eniID, publicIP := range publicIPs {
+			eniPublicIPs[eniID] = publicIP
+		}
+	}
+
+	return eniPublicIPs, nil
+}
+
+func (m *ECSTasksModule) loadPublicIPs(eniIDs []string, region string) (map[string]string, error) {
+	eniPublicIPs := make(map[string]string)
+
+	if len(eniIDs) == 0 {
+		return eniPublicIPs, nil
+	}
+
+	DescribeNetworkInterfaces, err := m.EC2Client.DescribeNetworkInterfaces(
+		context.TODO(),
+		&(ec2.DescribeNetworkInterfacesInput{
+			NetworkInterfaceIds: eniIDs,
+		}),
+		func(o *ec2.Options) {
+			o.Region = region
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting elastic network interfaces: %s", err)
+	}
+
+	for _, eni := range DescribeNetworkInterfaces.NetworkInterfaces {
+		eniPublicIPs[aws.ToString(eni.NetworkInterfaceId)] = getPublicIPOfElasticNetworkInterface(eni)
+	}
+
+	return eniPublicIPs, nil
+}
+
+func getNameFromARN(arn string) string {
+	tokens := strings.SplitN(arn, "/", 2)
+	if len(tokens) != 2 {
+		return arn
+	}
+
+	return tokens[1]
+}
+
+func getIDFromECSTask(arn string) string {
+	tokens := strings.SplitN(arn, "/", 3)
+	if len(tokens) != 3 {
+		return arn
+	}
+
+	return tokens[2]
+}
+
+func getPrivateIPv4AddressFromECSTask(task types.Task) string {
+	ips := []string{}
+
+	for _, attachment := range task.Attachments {
+		if aws.ToString(attachment.Type) != "ElasticNetworkInterface" || aws.ToString(attachment.Status) != "ATTACHED" {
+			continue
+		}
+
+		for _, kvp := range attachment.Details {
+			if aws.ToString(kvp.Name) == "privateIPv4Address" {
+				ips = append(ips, aws.ToString(kvp.Value))
+			}
+		}
+	}
+
+	return strings.Join(ips, "|")
+}
+
+func getElasticNetworkInterfaceIDOfECSTask(task types.Task) string {
+	for _, attachment := range task.Attachments {
+		if aws.ToString(attachment.Type) != "ElasticNetworkInterface" || aws.ToString(attachment.Status) != "ATTACHED" {
+			continue
+		}
+
+		for _, kvp := range attachment.Details {
+			if aws.ToString(kvp.Name) == "networkInterfaceId" {
+				return aws.ToString(kvp.Value)
+			}
+		}
+	}
+
+	return ""
+}

--- a/aws/ecs-tasks_test.go
+++ b/aws/ecs-tasks_test.go
@@ -1,0 +1,248 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+const DESCRIBE_TASKS_TEST_FILE = "./test-data/describe-tasks.json"
+const DESCRIBE_NETWORK_INTEFACES_TEST_FILE = "./test-data/describe-network-interfaces.json"
+
+type ListTasks struct {
+	TaskArns []string `json:"taskArns"`
+}
+
+type DescribeTasks struct {
+	Tasks []struct {
+		Attachments []struct {
+			ID      string `json:"id"`
+			Type    string `json:"type"`
+			Status  string `json:"status"`
+			Details []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"details"`
+		} `json:"attachments"`
+		Attributes []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"attributes"`
+		AvailabilityZone string `json:"availabilityZone"`
+		ClusterArn       string `json:"clusterArn"`
+		Connectivity     string `json:"connectivity"`
+		ConnectivityAt   string `json:"connectivityAt"`
+		Containers       []struct {
+			ContainerArn      string        `json:"containerArn"`
+			TaskArn           string        `json:"taskArn"`
+			Name              string        `json:"name"`
+			Image             string        `json:"image"`
+			RuntimeID         string        `json:"runtimeId"`
+			LastStatus        string        `json:"lastStatus"`
+			NetworkBindings   []interface{} `json:"networkBindings"`
+			NetworkInterfaces []struct {
+				AttachmentID       string `json:"attachmentId"`
+				PrivateIpv4Address string `json:"privateIpv4Address"`
+			} `json:"networkInterfaces"`
+			HealthStatus string `json:"healthStatus"`
+			CPU          string `json:"cpu"`
+			Memory       string `json:"memory"`
+		} `json:"containers"`
+		CPU                  string `json:"cpu"`
+		CreatedAt            string `json:"createdAt"`
+		DesiredStatus        string `json:"desiredStatus"`
+		EnableExecuteCommand bool   `json:"enableExecuteCommand"`
+		Group                string `json:"group"`
+		HealthStatus         string `json:"healthStatus"`
+		LastStatus           string `json:"lastStatus"`
+		LaunchType           string `json:"launchType"`
+		Memory               string `json:"memory"`
+		Overrides            struct {
+			ContainerOverrides []struct {
+				Name string `json:"name"`
+			} `json:"containerOverrides"`
+			InferenceAcceleratorOverrides []interface{} `json:"inferenceAcceleratorOverrides"`
+		} `json:"overrides"`
+		PlatformVersion   string        `json:"platformVersion"`
+		PlatformFamily    string        `json:"platformFamily"`
+		PullStartedAt     string        `json:"pullStartedAt"`
+		PullStoppedAt     string        `json:"pullStoppedAt"`
+		StartedAt         string        `json:"startedAt"`
+		StartedBy         string        `json:"startedBy"`
+		Tags              []interface{} `json:"tags"`
+		TaskArn           string        `json:"taskArn"`
+		TaskDefinitionArn string        `json:"taskDefinitionArn"`
+		Version           int           `json:"version"`
+		EphemeralStorage  struct {
+			SizeInGiB int `json:"sizeInGiB"`
+		} `json:"ephemeralStorage"`
+	} `json:"tasks"`
+	Failures []interface{} `json:"failures"`
+}
+
+type DescribeNetworkInterfaces struct {
+	NetworkInterfaces []struct {
+		Status          string `json:"Status"`
+		MacAddress      string `json:"MacAddress"`
+		SourceDestCheck bool   `json:"SourceDestCheck"`
+		VpcID           string `json:"VpcId"`
+		Description     string `json:"Description"`
+		Association     struct {
+			PublicIP      string `json:"PublicIp"`
+			AssociationID string `json:"AssociationId"`
+			PublicDNSName string `json:"PublicDnsName"`
+			IPOwnerID     string `json:"IpOwnerId"`
+		} `json:"Association"`
+		NetworkInterfaceID string `json:"NetworkInterfaceId"`
+		PrivateIPAddresses []struct {
+			PrivateDNSName string `json:"PrivateDnsName"`
+			Association    struct {
+				PublicIP      string `json:"PublicIp"`
+				AssociationID string `json:"AssociationId"`
+				PublicDNSName string `json:"PublicDnsName"`
+				IPOwnerID     string `json:"IpOwnerId"`
+			} `json:"Association"`
+			Primary          bool   `json:"Primary"`
+			PrivateIPAddress string `json:"PrivateIpAddress"`
+		} `json:"PrivateIpAddresses"`
+		RequesterManaged bool          `json:"RequesterManaged"`
+		Ipv6Addresses    []interface{} `json:"Ipv6Addresses"`
+		PrivateDNSName   string        `json:"PrivateDnsName,omitempty"`
+		AvailabilityZone string        `json:"AvailabilityZone"`
+		Attachment       struct {
+			Status              string    `json:"Status"`
+			DeviceIndex         int       `json:"DeviceIndex"`
+			AttachTime          time.Time `json:"AttachTime"`
+			InstanceID          string    `json:"InstanceId"`
+			DeleteOnTermination bool      `json:"DeleteOnTermination"`
+			AttachmentID        string    `json:"AttachmentId"`
+			InstanceOwnerID     string    `json:"InstanceOwnerId"`
+		} `json:"Attachment"`
+		Groups []struct {
+			GroupName string `json:"GroupName"`
+			GroupID   string `json:"GroupId"`
+		} `json:"Groups"`
+		SubnetID         string        `json:"SubnetId"`
+		OwnerID          string        `json:"OwnerId"`
+		TagSet           []interface{} `json:"TagSet"`
+		PrivateIPAddress string        `json:"PrivateIpAddress"`
+	} `json:"NetworkInterfaces"`
+}
+
+func readTestFile(testFile string) []byte {
+	file, err := os.ReadFile(testFile)
+	if err != nil {
+		log.Fatalf("can't read file %s", testFile)
+	}
+	return file
+}
+
+type mockedListclustersClient struct {
+}
+
+func (c *mockedListclustersClient) ListClusters(context.Context, *ecs.ListClustersInput, ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
+	return &ecs.ListClustersOutput{ClusterArns: []string{
+		"arn:aws:ecs:us-east-1:123456789012:cluster/MyCluster",
+		"arn:aws:ecs:us-east-1:123456789012:cluster/MyCluster2",
+		"arn:aws:ecs:us-east-1:123456789012:cluster/MyCluster3",
+	}}, nil
+}
+
+type mockedListTasksClient struct{}
+
+func (c *mockedListTasksClient) ListTasks(ctx context.Context, input *ecs.ListTasksInput, f ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
+	return &ecs.ListTasksOutput{TaskArns: []string{
+		"arn:aws:ecs:us-east-1:123456789012:task/MyCluster/74de0355a10a4f979ac495c14EXAMPLE",
+		"arn:aws:ecs:us-east-1:123456789012:task/MyCluster/d789e94343414c25b9f6bd59eEXAMPLE",
+	}}, nil
+}
+
+type mockedDescribeTasksClient struct {
+	describeTasks DescribeTasks
+}
+
+func (c *mockedDescribeTasksClient) DescribeTasks(ctx context.Context, input *ecs.DescribeTasksInput, f ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
+	err := json.Unmarshal(readTestFile(DESCRIBE_TASKS_TEST_FILE), &c.describeTasks)
+	if err != nil {
+		log.Fatalf("can't unmarshall file %s", DESCRIBE_TASKS_TEST_FILE)
+	}
+	var tasks []ecsTypes.Task
+	for _, mockedTask := range c.describeTasks.Tasks {
+		if mockedTask.ClusterArn == aws.ToString(input.Cluster) {
+			for _, inputTask := range input.Tasks {
+				if mockedTask.TaskArn == inputTask {
+					var attachments []ecsTypes.Attachment
+					for _, a := range mockedTask.Attachments {
+						var deets []ecsTypes.KeyValuePair
+						for _, detail := range a.Details {
+							deets = append(deets, ecsTypes.KeyValuePair{
+								Name:  aws.String(detail.Name),
+								Value: aws.String(detail.Value)})
+						}
+						attachments = append(attachments, ecsTypes.Attachment{
+							Type:    aws.String(a.Type),
+							Details: deets,
+							Id:      aws.String(a.ID),
+							Status:  aws.String(a.Status),
+						})
+					}
+					tasks = append(tasks, ecsTypes.Task{
+						ClusterArn:        aws.String(mockedTask.ClusterArn),
+						TaskDefinitionArn: aws.String(mockedTask.TaskDefinitionArn),
+						LaunchType:        ecsTypes.LaunchType(*aws.String(mockedTask.LaunchType)),
+						TaskArn:           aws.String(mockedTask.TaskArn),
+						Attachments:       attachments,
+					})
+				}
+			}
+		}
+	}
+	return &ecs.DescribeTasksOutput{Tasks: tasks}, nil
+}
+
+type mockedDescribeNetworkInterfacesClient struct {
+	describeNetworkInterfaces DescribeNetworkInterfaces
+}
+
+func (c *mockedDescribeNetworkInterfacesClient) DescribeNetworkInterfaces(ctx context.Context, input *ec2.DescribeNetworkInterfacesInput, f ...func(o *ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	var nics []ec2types.NetworkInterface
+	err := json.Unmarshal(readTestFile(DESCRIBE_NETWORK_INTEFACES_TEST_FILE), &c.describeNetworkInterfaces)
+	if err != nil {
+		log.Fatalf("can't unmarshall file %s", DESCRIBE_NETWORK_INTEFACES_TEST_FILE)
+	}
+	for _, mockedNic := range c.describeNetworkInterfaces.NetworkInterfaces {
+		for _, inputNicID := range input.NetworkInterfaceIds {
+			if mockedNic.NetworkInterfaceID == inputNicID {
+				nics = append(nics, ec2types.NetworkInterface{
+					Association: &ec2types.NetworkInterfaceAssociation{
+						PublicIp: aws.String(mockedNic.Association.PublicIP),
+					},
+					NetworkInterfaceId: aws.String(mockedNic.NetworkInterfaceID)})
+			}
+		}
+	}
+	return &ec2.DescribeNetworkInterfacesOutput{NetworkInterfaces: nics}, nil
+}
+
+func TestECSTasks(t *testing.T) {
+	m := ECSTasksModule{
+		AWSProfile:                      "default",
+		AWSRegions:                      []string{"us-east-1", "us-west-1"},
+		Caller:                          sts.GetCallerIdentityOutput{Arn: aws.String("arn:aws:iam::123456789012:user/cloudfox_unit_tests")},
+		DescribeNetworkInterfacesClient: &mockedDescribeNetworkInterfacesClient{},
+		DescribeTasksClient:             &mockedDescribeTasksClient{},
+		ListTasksClient:                 &mockedListTasksClient{},
+		ListClustersClient:              &mockedListclustersClient{},
+	}
+	m.ECSTasks("table", ".", 3)
+}

--- a/aws/elastic-network-interfaces.go
+++ b/aws/elastic-network-interfaces.go
@@ -1,0 +1,242 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/BishopFox/cloudfox/console"
+	"github.com/BishopFox/cloudfox/utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/sirupsen/logrus"
+)
+
+type ElasticNetworkInterfacesModule struct {
+	EC2Client *ec2.Client
+
+	Caller       sts.GetCallerIdentityOutput
+	AWSRegions   []string
+	OutputFormat string
+	AWSProfile   string
+
+	MappedENIs     []MappedENI
+	CommandCounter console.CommandCounter
+
+	output utils.OutputData2
+	modLog *logrus.Entry
+}
+
+type MappedENI struct {
+	ID               string
+	Type             string
+	ExternalIP       string
+	PrivateIP        string
+	VPCID            string
+	AttachedInstance string
+	Description      string
+}
+
+func (m *ElasticNetworkInterfacesModule) ElasticNetworkInterfaces(outputFormat string, outputDirectory string, verbosity int) {
+	m.output.Verbosity = verbosity
+	m.output.Directory = outputDirectory
+	m.output.CallingModule = "elastic-network-interfaces"
+	m.modLog = utils.TxtLog.WithFields(logrus.Fields{
+		"module": m.output.CallingModule,
+	})
+	if m.AWSProfile == "" {
+		m.AWSProfile = utils.BuildAWSPath(m.Caller)
+	}
+
+	fmt.Printf("[%s][%s] Enumerating elastic network interfaces in all regions for account %s\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), aws.ToString(m.Caller.Account))
+
+	wg := new(sync.WaitGroup)
+
+	spinnerDone := make(chan bool)
+	go console.SpinUntil(m.output.CallingModule, &m.CommandCounter, spinnerDone, "tasks")
+
+	dataReceiver := make(chan MappedENI)
+	receiverDone := make(chan bool)
+	go m.Receiver(dataReceiver, receiverDone)
+
+	for _, region := range m.AWSRegions {
+		wg.Add(1)
+		m.CommandCounter.Pending++
+		go m.executeChecks(region, wg, dataReceiver)
+
+	}
+
+	wg.Wait()
+	spinnerDone <- true
+	<-spinnerDone
+	receiverDone <- true
+	<-receiverDone
+
+	m.printENIsData(outputFormat, outputDirectory, dataReceiver)
+
+}
+
+func (m *ElasticNetworkInterfacesModule) Receiver(receiver chan MappedENI, receiverDone chan bool) {
+	defer close(receiverDone)
+	for {
+		select {
+		case data := <-receiver:
+			m.MappedENIs = append(m.MappedENIs, data)
+		case <-receiverDone:
+			receiverDone <- true
+			return
+		}
+	}
+}
+
+func (m *ElasticNetworkInterfacesModule) printENIsData(outputFormat string, outputDirectory string, dataReceiver chan MappedENI) {
+	m.output.Headers = []string{
+		"ID",
+		"Type",
+		"External IP",
+		"Internal IP",
+		"VPC ID",
+		"Attached Instance",
+		"Description",
+	}
+	for _, eni := range m.MappedENIs {
+		m.output.Body = append(
+			m.output.Body,
+			[]string{
+				eni.ID,
+				eni.Type,
+				eni.ExternalIP,
+				eni.PrivateIP,
+				eni.VPCID,
+				eni.AttachedInstance,
+				eni.Description,
+			},
+		)
+	}
+	if len(m.output.Body) > 0 {
+		m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", m.AWSProfile)
+		utils.OutputSelector(m.output.Verbosity, outputFormat, m.output.Headers, m.output.Body, m.output.FilePath, m.output.CallingModule, m.output.CallingModule)
+
+		m.writeLoot(m.output.FilePath)
+		fmt.Printf("[%s][%s] %s elastic network interfaces found.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), strconv.Itoa(len(m.output.Body)))
+
+	} else {
+		fmt.Printf("[%s][%s] No elastic network interfaces found, skipping the creation of an output file.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile))
+	}
+}
+
+func (m *ElasticNetworkInterfacesModule) writeLoot(outputDirectory string) {
+	path := filepath.Join(outputDirectory, "loot")
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+	}
+	privateIPsFilename := filepath.Join(path, "elastic-network-interfaces-PrivateIPs.txt")
+	publicIPsFilename := filepath.Join(path, "elastic-network-interfaces-PublicIPs.txt")
+
+	var publicIPs string
+	var privateIPs string
+
+	for _, eni := range m.MappedENIs {
+		if eni.ExternalIP != "NoExternalIP" {
+			publicIPs = publicIPs + fmt.Sprintln(eni.ExternalIP)
+		}
+		if eni.PrivateIP != "" {
+			privateIPs = privateIPs + fmt.Sprintln(eni.PrivateIP)
+		}
+
+	}
+	err = os.WriteFile(privateIPsFilename, []byte(privateIPs), 0644)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+	}
+	err = os.WriteFile(publicIPsFilename, []byte(publicIPs), 0644)
+	if err != nil {
+		m.modLog.Error(err.Error())
+		m.CommandCounter.Error++
+	}
+
+	fmt.Printf("[%s][%s] Loot written to [%s]\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), privateIPsFilename)
+	fmt.Printf("[%s][%s] Loot written to [%s]\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), publicIPsFilename)
+
+}
+
+func (m *ElasticNetworkInterfacesModule) executeChecks(r string, wg *sync.WaitGroup, dataReceiver chan MappedENI) {
+	defer wg.Done()
+	m.CommandCounter.Total++
+	m.CommandCounter.Pending--
+	m.CommandCounter.Executing++
+	m.getDescribeNetworkInterfaces(r, dataReceiver)
+	m.CommandCounter.Executing--
+	m.CommandCounter.Complete++
+}
+
+func (m *ElasticNetworkInterfacesModule) getDescribeNetworkInterfaces(region string, dataReceiver chan MappedENI) {
+	var PaginationControl *string
+	for {
+		DescribeNetworkInterfaces, err := m.EC2Client.DescribeNetworkInterfaces(
+			context.TODO(),
+			&(ec2.DescribeNetworkInterfacesInput{
+				NextToken: PaginationControl,
+			}),
+			func(o *ec2.Options) {
+				o.Region = region
+			},
+		)
+		if err != nil {
+			m.modLog.Error(err.Error())
+			m.CommandCounter.Error++
+			break
+		}
+
+		for _, eni := range DescribeNetworkInterfaces.NetworkInterfaces {
+			status := string(eni.Status)
+			if status == "available" {
+				continue // unused ENI
+			}
+
+			mappedENI := MappedENI{
+				ID:               aws.ToString(eni.NetworkInterfaceId),
+				Type:             string(eni.InterfaceType),
+				ExternalIP:       getPublicIPOfElasticNetworkInterface(eni),
+				PrivateIP:        aws.ToString(eni.PrivateIpAddress),
+				VPCID:            aws.ToString(eni.VpcId),
+				AttachedInstance: getAttachmentInstanceOfElasticNetworkInterface(eni),
+				Description:      aws.ToString(eni.Description),
+			}
+
+			dataReceiver <- mappedENI
+		}
+
+		if DescribeNetworkInterfaces.NextToken != nil {
+			PaginationControl = DescribeNetworkInterfaces.NextToken
+		} else {
+			PaginationControl = nil
+			break
+		}
+
+	}
+}
+
+func getPublicIPOfElasticNetworkInterface(elasticNetworkInterface types.NetworkInterface) string {
+	if elasticNetworkInterface.Association != nil {
+		return aws.ToString(elasticNetworkInterface.Association.PublicIp)
+	}
+
+	return "NoExternalIP"
+}
+
+func getAttachmentInstanceOfElasticNetworkInterface(elasticNetworkInterface types.NetworkInterface) string {
+	if elasticNetworkInterface.Attachment == nil {
+		return ""
+	}
+
+	return aws.ToString(elasticNetworkInterface.Attachment.InstanceId)
+}

--- a/aws/elastic-network-interfaces.go
+++ b/aws/elastic-network-interfaces.go
@@ -18,7 +18,8 @@ import (
 )
 
 type ElasticNetworkInterfacesModule struct {
-	EC2Client *ec2.Client
+	//EC2Client                       *ec2.Client
+	DescribeNetworkInterfacesClient ec2.DescribeNetworkInterfacesAPIClient
 
 	Caller       sts.GetCallerIdentityOutput
 	AWSRegions   []string
@@ -181,7 +182,7 @@ func (m *ElasticNetworkInterfacesModule) executeChecks(r string, wg *sync.WaitGr
 func (m *ElasticNetworkInterfacesModule) getDescribeNetworkInterfaces(region string, dataReceiver chan MappedENI) {
 	var PaginationControl *string
 	for {
-		DescribeNetworkInterfaces, err := m.EC2Client.DescribeNetworkInterfaces(
+		DescribeNetworkInterfaces, err := m.DescribeNetworkInterfacesClient.DescribeNetworkInterfaces(
 			context.TODO(),
 			&(ec2.DescribeNetworkInterfacesInput{
 				NextToken: PaginationControl,

--- a/aws/elastic-network-interfaces_test.go
+++ b/aws/elastic-network-interfaces_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/BishopFox/cloudfox/utils"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -39,7 +38,6 @@ func (c *mockedDescribeNetworkInterfacesClient2) DescribeNetworkInterfaces(ctx c
 }
 
 func TestElasticNetworkInterfaces(t *testing.T) {
-	utils.FileSystem = utils.MockFileSystem(true)
 	m := ElasticNetworkInterfacesModule{
 		AWSProfile:                      "default",
 		AWSRegions:                      []string{"us-east-1", "us-west-1"},

--- a/aws/elastic-network-interfaces_test.go
+++ b/aws/elastic-network-interfaces_test.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"testing"
+
+	"github.com/BishopFox/cloudfox/utils"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type mockedDescribeNetworkInterfacesClient2 struct {
+	describeNetworkInterfaces DescribeNetworkInterfaces
+}
+
+func (c *mockedDescribeNetworkInterfacesClient2) DescribeNetworkInterfaces(ctx context.Context, input *ec2.DescribeNetworkInterfacesInput, f ...func(o *ec2.Options)) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	var nics []ec2types.NetworkInterface
+	err := json.Unmarshal(readTestFile(DESCRIBE_NETWORK_INTEFACES_TEST_FILE), &c.describeNetworkInterfaces)
+	if err != nil {
+		log.Fatalf("can't unmarshall file %s", DESCRIBE_NETWORK_INTEFACES_TEST_FILE)
+	}
+	for _, mockednic := range c.describeNetworkInterfaces.NetworkInterfaces {
+		nics = append(nics, ec2types.NetworkInterface{
+			Association: &ec2types.NetworkInterfaceAssociation{
+				PublicIp: aws.String(mockednic.Association.PublicIP),
+			},
+			NetworkInterfaceId: aws.String(mockednic.NetworkInterfaceID),
+			PrivateIpAddress:   aws.String(mockednic.PrivateIPAddress),
+			VpcId:              aws.String(mockednic.VpcID),
+			Attachment:         &ec2types.NetworkInterfaceAttachment{InstanceId: aws.String(mockednic.Attachment.InstanceID)},
+			Description:        aws.String(mockednic.Description),
+		})
+	}
+	return &ec2.DescribeNetworkInterfacesOutput{NetworkInterfaces: nics}, nil
+}
+
+func TestElasticNetworkInterfaces(t *testing.T) {
+	utils.FileSystem = utils.MockFileSystem(true)
+	m := ElasticNetworkInterfacesModule{
+		AWSProfile:                      "default",
+		AWSRegions:                      []string{"us-east-1", "us-west-1"},
+		Caller:                          sts.GetCallerIdentityOutput{Arn: aws.String("arn:aws:iam::123456789012:user/cloudfox_unit_tests")},
+		DescribeNetworkInterfacesClient: &mockedDescribeNetworkInterfacesClient2{},
+	}
+	m.ElasticNetworkInterfaces("table", ".", 3)
+}

--- a/aws/test-data/describe-network-interfaces.json
+++ b/aws/test-data/describe-network-interfaces.json
@@ -1,0 +1,98 @@
+{
+    "NetworkInterfaces": [
+        {
+            "Status": "in-use",
+            "MacAddress": "02:2f:8f:b0:cf:75",
+            "SourceDestCheck": true,
+            "VpcId": "vpc-a01106c2",
+            "Description": "my network interface",
+            "Association": {
+                "PublicIp": "203.0.113.12",
+                "AssociationId": "eipassoc-0fbb766a",
+                "PublicDnsName": "ec2-203-0-113-12.compute-1.amazonaws.com",
+                "IpOwnerId": "123456789012"
+            },
+            "NetworkInterfaceId": "eni-e5aa89a3",
+            "PrivateIpAddresses": [
+                {
+                    "PrivateDnsName": "ip-10-0-1-17.ec2.internal",
+                    "Association": {
+                        "PublicIp": "203.0.113.12",
+                        "AssociationId": "eipassoc-0fbb766a",
+                        "PublicDnsName": "ec2-203-0-113-12.compute-1.amazonaws.com",
+                        "IpOwnerId": "123456789012"
+                    },
+                    "Primary": true,
+                    "PrivateIpAddress": "10.0.1.17"
+                }
+            ],
+            "RequesterManaged": false,
+            "Ipv6Addresses": [],
+            "PrivateDnsName": "ip-10-0-1-17.ec2.internal",
+            "AvailabilityZone": "us-east-1d",
+            "Attachment": {
+                "Status": "attached",
+                "DeviceIndex": 1,
+                "AttachTime": "2013-11-30T23:36:42.000Z",
+                "InstanceId": "i-1234567890abcdef0",
+                "DeleteOnTermination": false,
+                "AttachmentId": "eni-attach-66c4350a",
+                "InstanceOwnerId": "123456789012"
+            },
+            "Groups": [
+                {
+                    "GroupName": "default",
+                    "GroupId": "sg-8637d3e3"
+                }
+            ],
+            "SubnetId": "subnet-b61f49f0",
+            "OwnerId": "123456789012",
+            "TagSet": [],
+            "PrivateIpAddress": "10.0.1.17"
+        },
+        {
+            "Status": "in-use",
+            "MacAddress": "02:58:f5:ef:4b:06",
+            "SourceDestCheck": true,
+            "VpcId": "vpc-a01106c2",
+            "Description": "Primary network interface",
+            "Association": {
+                "PublicIp": "198.51.100.0",
+                "IpOwnerId": "amazon"
+            },
+            "NetworkInterfaceId": "eni-f9ba99bf",
+            "PrivateIpAddresses": [
+                {
+                    "Association": {
+                        "PublicIp": "198.51.100.0",
+                        "IpOwnerId": "amazon"
+                    },
+                    "Primary": true,
+                    "PrivateIpAddress": "10.0.1.149"
+                }
+            ],
+            "RequesterManaged": false,
+            "Ipv6Addresses": [],
+            "AvailabilityZone": "us-east-1d",
+            "Attachment": {
+                "Status": "attached",
+                "DeviceIndex": 0,
+                "AttachTime": "2013-11-30T23:35:33.000Z",
+                "InstanceId": "i-0598c7d356eba48d7",
+                "DeleteOnTermination": true,
+                "AttachmentId": "eni-attach-1b9db777",
+                "InstanceOwnerId": "123456789012"
+            },
+            "Groups": [
+                {
+                    "GroupName": "default",
+                    "GroupId": "sg-8637d3e3"
+                }
+            ],
+            "SubnetId": "subnet-b61f49f0",
+            "OwnerId": "123456789012",
+            "TagSet": [],
+            "PrivateIpAddress": "10.0.1.149"
+        }
+    ]
+  }

--- a/aws/test-data/describe-tasks.json
+++ b/aws/test-data/describe-tasks.json
@@ -1,0 +1,187 @@
+{
+    "tasks": [
+        {
+            "attachments": [
+                {
+                    "id": "d9e7735a-16aa-4128-bc7a-b2d51EXAMPLE",
+                    "type": "ElasticNetworkInterface",
+                    "status": "ATTACHED",
+                    "details": [
+                        {
+                            "name": "subnetId",
+                            "value": "subnet-0d0eab1bb3EXAMPLE"
+                        },
+                        {
+                            "name": "networkInterfaceId",
+                            "value": "eni-f9ba99bf"
+                        },
+                        {
+                            "name": "macAddress",
+                            "value": "0e:89:76:28:07:b3"
+                        },
+                        {
+                            "name": "privateDnsName",
+                            "value": "ip-10-0-1-184.ec2.internal"
+                        },
+                        {
+                            "name": "privateIPv4Address",
+                            "value": "10.0.1.184"
+                        }
+                    ]
+                }
+            ],
+            "attributes": [
+                {
+                    "name": "ecs.cpu-architecture",
+                    "value": "x86_64"
+                }
+            ],
+            "availabilityZone": "us-east-1b",
+            "clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/MyCluster",
+            "connectivity": "CONNECTED",
+            "connectivityAt": "2021-12-20T12:13:37.875000-05:00",
+            "containers": [
+                {
+                    "containerArn": "arn:aws:ecs:us-east-1:123456789012:container/MyCluster/74de0355a10a4f979ac495c14EXAMPLE/aad3ba00-83b3-4dac-84d4-11f8cEXAMPLE",
+                    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/MyCluster/74de0355a10a4f979ac495c14EXAMPLE",
+                    "name": "web",
+                    "image": "nginx",
+                    "runtimeId": "74de0355a10a4f979ac495c14EXAMPLE-265927825",
+                    "lastStatus": "RUNNING",
+                    "networkBindings": [],
+                    "networkInterfaces": [
+                        {
+                            "attachmentId": "d9e7735a-16aa-4128-bc7a-b2d51EXAMPLE",
+                            "privateIpv4Address": "10.0.1.184"
+                        }
+                    ],
+                    "healthStatus": "UNKNOWN",
+                    "cpu": "99",
+                    "memory": "100"
+                }
+            ],
+            "cpu": "256",
+            "createdAt": "2021-12-20T12:13:20.226000-05:00",
+            "desiredStatus": "RUNNING",
+            "enableExecuteCommand": false,
+            "group": "service:tdsevicetag",
+            "healthStatus": "UNKNOWN",
+            "lastStatus": "RUNNING",
+            "launchType": "FARGATE",
+            "memory": "512",
+            "overrides": {
+                "containerOverrides": [
+                    {
+                        "name": "web"
+                    }
+                ],
+                "inferenceAcceleratorOverrides": []
+            },
+            "platformVersion": "1.4.0",
+            "platformFamily": "Linux",
+            "pullStartedAt": "2021-12-20T12:13:42.665000-05:00",
+            "pullStoppedAt": "2021-12-20T12:13:46.543000-05:00",
+            "startedAt": "2021-12-20T12:13:48.086000-05:00",
+            "startedBy": "ecs-svc/988401040018EXAMPLE",
+            "tags": [],
+            "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/MyCluster/74de0355a10a4f979ac495c14EXAMPLE",
+            "taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/webserver:2",
+            "version": 3,
+            "ephemeralStorage": {
+            "sizeInGiB": 20
+            }
+        },
+        {
+            "attachments": [
+                {
+                    "id": "214eb5a9-45cd-4bf8-87bc-57fefEXAMPLE",
+                    "type": "ElasticNetworkInterface",
+                    "status": "ATTACHED",
+                    "details": [
+                        {
+                            "name": "subnetId",
+                            "value": "subnet-0d0eab1bb3EXAMPLE"
+                        },
+                        {
+                            "name": "networkInterfaceId",
+                            "value": "eni-e5aa89a3"
+                        },
+                        {
+                            "name": "macAddress",
+                            "value": "0e:76:83:01:17:a9"
+                        },
+                        {
+                            "name": "privateDnsName",
+                            "value": "ip-10-0-1-41.ec2.internal"
+                        },
+                        {
+                            "name": "privateIPv4Address",
+                            "value": "10.0.1.41"
+                        }
+                    ]
+                }
+            ],
+            "attributes": [
+                {
+                    "name": "ecs.cpu-architecture",
+                    "value": "x86_64"
+                }
+            ],
+            "availabilityZone": "us-east-1b",
+            "clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/MyCluster",
+            "connectivity": "CONNECTED",
+            "connectivityAt": "2021-12-20T12:13:35.243000-05:00",
+            "containers": [
+                {
+                    "containerArn": "arn:aws:ecs:us-east-1:123456789012:container/MyCluster/d789e94343414c25b9f6bd59eEXAMPLE/9afef792-609b-43a5-bb6a-3efdbEXAMPLE",
+                    "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/MyCluster/d789e94343414c25b9f6bd59eEXAMPLE",
+                    "name": "web",
+                    "image": "nginx",
+                    "runtimeId": "d789e94343414c25b9f6bd59eEXAMPLE-265927825",
+                    "lastStatus": "RUNNING",
+                    "networkBindings": [],
+                    "networkInterfaces": [
+                        {
+                            "attachmentId": "214eb5a9-45cd-4bf8-87bc-57fefEXAMPLE",
+                            "privateIpv4Address": "10.0.1.41"
+                        }
+                    ],
+                    "healthStatus": "UNKNOWN",
+                    "cpu": "99",
+                    "memory": "100"
+                }
+            ],
+            "cpu": "256",
+            "createdAt": "2021-12-20T12:13:20.226000-05:00",
+            "desiredStatus": "RUNNING",
+            "enableExecuteCommand": false,
+            "group": "service:tdsevicetag",
+            "healthStatus": "UNKNOWN",
+            "lastStatus": "RUNNING",
+            "launchType": "FARGATE",
+            "memory": "512",
+            "overrides": {
+                "containerOverrides": [
+                    {
+                        "name": "web"
+                    }
+                ],
+                "inferenceAcceleratorOverrides": []
+            },
+            "platformVersion": "1.4.0",
+            "platformFamily": "Linux",
+            "pullStartedAt": "2021-12-20T12:13:44.611000-05:00",
+            "pullStoppedAt": "2021-12-20T12:13:48.251000-05:00",
+            "startedAt": "2021-12-20T12:13:49.326000-05:00",
+            "startedBy": "ecs-svc/988401040018EXAMPLE",
+            "tags": [],
+            "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/MyCluster/d789e94343414c25b9f6bd59eEXAMPLE",
+            "taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/webserver:2",
+            "version": 3,
+            "ephemeralStorage": {
+                "sizeInGiB": 20
+            }
+        }
+    ],
+    "failures": []
+}

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -425,8 +425,12 @@ var (
 					continue
 				}
 				m := aws.ECSTasksModule{
-					ECSClient: ecs.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
-					EC2Client: ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					//ECSClient:           ecs.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					DescribeTasksClient: ecs.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					ListTasksClient:     ecs.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					ListClustersClient:  ecs.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					//EC2Client:                       ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					DescribeNetworkInterfacesClient: ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
 
 					Caller:     *caller,
 					AWSRegions: AWSRegions,
@@ -460,7 +464,8 @@ var (
 					continue
 				}
 				m := aws.ElasticNetworkInterfacesModule{
-					EC2Client: ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					//EC2Client:                       ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					DescribeNetworkInterfacesClient: ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
 
 					Caller:     *caller,
 					AWSRegions: AWSRegions,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -403,6 +403,75 @@ var (
 		},
 	}
 
+	ECSTasksCommand = &cobra.Command{
+		Use:     "ecs-tasks",
+		Aliases: []string{"ecs"},
+		Short:   "Enumerate all ECS tasks along with assigned IPs and profiles",
+		Long: "\nUse case examples:\n" +
+			os.Args[0] + " aws ecs-tasks --profile readonly_profile",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			for _, profile := range AWSProfiles {
+				caller, err := utils.AWSWhoami(profile, cmd.Root().Version)
+				if err != nil {
+					continue
+				}
+				fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, profile := range AWSProfiles {
+				caller, err := utils.AWSWhoami(profile, cmd.Root().Version)
+				if err != nil {
+					continue
+				}
+				m := aws.ECSTasksModule{
+					ECSClient: ecs.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+					EC2Client: ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+
+					Caller:     *caller,
+					AWSRegions: AWSRegions,
+
+					AWSProfile: profile,
+				}
+				m.ECSTasks(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+			}
+		},
+	}
+
+	ElasticNetworkInterfacesCommand = &cobra.Command{
+		Use:     "elastic-network-interfaces",
+		Aliases: []string{"eni"},
+		Short:   "Enumerate all elastic network interafces along with their private and public IPs and the VPC",
+		Long: "\nUse case examples:\n" +
+			os.Args[0] + " aws elastic-network-interfaces --profile readonly_profile",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			for _, profile := range AWSProfiles {
+				caller, err := utils.AWSWhoami(profile, cmd.Root().Version)
+				if err != nil {
+					continue
+				}
+				fmt.Printf("[%s] AWS Caller Identity: %s\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", cmd.Root().Version)), *caller.Arn)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, profile := range AWSProfiles {
+				caller, err := utils.AWSWhoami(profile, cmd.Root().Version)
+				if err != nil {
+					continue
+				}
+				m := aws.ElasticNetworkInterfacesModule{
+					EC2Client: ec2.NewFromConfig(utils.AWSConfigFileLoader(profile, cmd.Root().Version)),
+
+					Caller:     *caller,
+					AWSRegions: AWSRegions,
+
+					AWSProfile: profile,
+				}
+				m.ElasticNetworkInterfaces(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+			}
+		},
+	}
+
 	InventoryCommand = &cobra.Command{
 		Use:   "inventory",
 		Short: "Gain a rough understanding of size of the account and preferred regions",
@@ -1107,6 +1176,8 @@ func init() {
 		RoleTrustCommand,
 		AccessKeysCommand,
 		InstancesCommand,
+		ECSTasksCommand,
+		ElasticNetworkInterfacesCommand,
 		InventoryCommand,
 		EndpointsCommand,
 		SecretsCommand,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1015,8 +1015,27 @@ var (
 					AWSProfile: profile,
 					Goroutines: Goroutines,
 				}
-
 				endpoints.PrintEndpoints(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+
+				ecstasks := aws.ECSTasksModule{
+					DescribeTasksClient:             ecsClient,
+					ListTasksClient:                 ecsClient,
+					ListClustersClient:              ecsClient,
+					DescribeNetworkInterfacesClient: ec2Client,
+					Caller:                          *Caller,
+					AWSRegions:                      AWSRegions,
+					AWSProfile:                      profile,
+				}
+				ecstasks.ECSTasks(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+
+				elasticnetworkinterfaces := aws.ElasticNetworkInterfacesModule{
+					DescribeNetworkInterfacesClient: ec2Client,
+					Caller:                          *Caller,
+					AWSRegions:                      AWSRegions,
+					AWSProfile:                      profile,
+				}
+				elasticnetworkinterfaces.ElasticNetworkInterfaces(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+
 				// Secrets section
 				fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("Looking for secrets hidden between the seat cushions."))
 
@@ -1031,6 +1050,7 @@ var (
 					Goroutines:             Goroutines,
 				}
 				ec2UserData.Instances(InstancesFilter, AWSOutputFormat, AWSOutputDirectory, Verbosity)
+
 				envsMod := aws.EnvsModule{
 
 					Caller:          *Caller,

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:     os.Args[0],
-		Version: "1.8.0",
+		Version: "1.9.0",
 	}
 )
 


### PR DESCRIPTION
#### Card

Proposal for two additional commands, roughly implemented in this draft PR.
- ecs-tasks: lists all ECS task with their private and possibly public IP addresses - to find exposed ECS workloads
- elastic-network-interfaces: lists als ENIs with their private and possibly public IP addresses - to find exposed workloads or also to get a general overview of what is inside the VPC

The implementations should not require more than a handful or requests for each region. Tried to batch as much as possible.

Let me know if this is interesting to you. I'm happy to brush up the code if it is.

#### Details

##### ecs-tasks

Enumerates all ECS tasks and shows you:
- Cluster: just the name
- TaskDefinition: the name and version
- LaunchType: fargate, ec2 or external
- ID: the ID extracted from the task ARN
- External IP: if available, else `NoExternalIP`
- Internal IP: ...

I like it to see if any tasks could be exposed to the internet and also because cluster and task definition names can give you a rough overview of what's running.

#####  elastic-network-interfaces

Enumerates all EC2 elastic network interfaces (except those that have status `available` which means not used) and shows you:
- ID: just the ID of it
- Type: broad category, possible values [here](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2@v1.65.0/types#NetworkInterfaceType)
- External IP: if available, else `NoExternalIP`
- Internal IP: ...
- VPC ID: ...
- Attached Instance: EC2 instance ID if ENI belongs to an EC2, else empty
- Description: a nice description AWS attaches to ENIs to explain you what they are good for

I like to list ENIs because you get to see pretty much everything that supports VPC networking, along with the IP addresses. The list can contain hints to resources of less popular services that you would otherwise not enumerate (look at descriptions).