### PR TITLE
typo: ssm:sSendCommand has extra s

### DIFF
--- a/aws/iam-simulator.go
+++ b/aws/iam-simulator.go
@@ -53,7 +53,7 @@ var (
 		"ssm:GetParameter",
 		"s3:ListBucket",
 		"s3:GetObject",
-		"ssm:sSendCommand",
+		"ssm:SendCommand",
 		"ssm:StartSession",
 		"ecr:BatchGetImage",
 		"ecr:GetAuthorizationToken",


### PR DESCRIPTION
Typo: ssm:sSendCommand should be ssm:SendCommand