### PR TITLE
bugfix 'SQS' and 'SNS' are inspected when 'all-checks' is executed.

### DIFF
--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1410,6 +1410,32 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		}
 		iamSimulator.PrintIamSimulator(SimulatorPrincipal, SimulatorAction, SimulatorResource, AWSOutputFormat, AWSOutputDirectory, Verbosity)
 
+		sqsMod := aws.SQSModule{
+			SQSClient: sqsClient,
+
+			StorePolicies: StoreSQSAccessPolicies,
+
+			Caller:     *Caller,
+			AWSRegions: internal.GetEnabledRegions(profile, cmd.Root().Version),
+			AWSProfile: profile,
+			Goroutines: Goroutines,
+			WrapTable:  AWSWrapTable,
+		}
+		sqsMod.PrintSQS(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+
+		snsMod := aws.SNSModule{
+			SNSClient: snsClient,
+
+			StorePolicies: StoreSNSAccessPolicies,
+
+			Caller:     *Caller,
+			AWSRegions: internal.GetEnabledRegions(profile, cmd.Root().Version),
+			AWSProfile: profile,
+			Goroutines: Goroutines,
+			WrapTable:  AWSWrapTable,
+		}
+		snsMod.PrintSNS(AWSOutputFormat, AWSOutputDirectory, Verbosity)
+
 		fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("That's it! Check your output files for situational awareness and check your loot files for next steps."))
 		fmt.Printf("[%s] %s\n\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("FYI, we skipped the outbound-assumed-roles module in all-checks (really long run time). Make sure to try it out manually."))
 	}


### PR DESCRIPTION
#### Card

- ISSUE: #34 

#### Details

When "cloudfox aws all-checks" was specified at runtime, "sns" and "sqs" were not checked.

Fixed so that "SNS" and "SQS" inspections are also performed.
