### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For the full documentation please refer to our [wiki](https://github.com/BishopF
 ### AWS
 * AWS CLI installed
 * Supports AWS profiles, AWS environment variables, or metadata retrieval (on an ec2 instance)
-   * To run commands on multiple profiles at once, you can specify the path to a file with a list of profile names seperated by a new line using the `-l` flag or pass all stored profiles with the `-a` flag.
+   * To run commands on multiple profiles at once, you can specify the path to a file with a list of profile names separated by a new line using the `-l` flag or pass all stored profiles with the `-a` flag.
 * A principal with one recommended policies attached (described below)
 * Recommended attached policies: **`SecurityAudit` + [CloudFox custom policy](./misc/aws/cloudfox-policy.json)** 
 
@@ -138,7 +138,7 @@ CloudFox doesn't create any alerts or findings, and doesn't check your environme
 
 **Why do I see errors in some CloudFox commands?**
 
-* Services that don't exist in all regions - CloudFox tries a few ways to figure out what services are supported in each region. However some services don't support the methods CloudFox uses, so CloudFox defaults to just asking every region about the service. Regions that don't suppor the service will return errors. 
+* Services that don't exist in all regions - CloudFox tries a few ways to figure out what services are supported in each region. However some services don't support the methods CloudFox uses, so CloudFox defaults to just asking every region about the service. Regions that don't support the service will return errors. 
 * You don't have permission - Another reason you might see errors if you don't have permissions to make calls that CloudFox is making. Either because the policy doesn't allow it (e.g., SecurityAudit doesn't allow all of the permissions CloudFox needs. Or, it might be an SCP that is blocking you.  
 
 You can always look in the ~/.cloudfox/cloudfox-error.log file to get more information on errors. 

--- a/aws/access-keys.go
+++ b/aws/access-keys.go
@@ -37,7 +37,7 @@ type UserKeys struct {
 }
 
 func (m *AccessKeysModule) PrintAccessKeys(filter string, outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "access-keys"

--- a/aws/buckets.go
+++ b/aws/buckets.go
@@ -54,7 +54,7 @@ type Bucket struct {
 }
 
 func (m *BucketsModule) PrintBuckets(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "buckets"

--- a/aws/cloudformation.go
+++ b/aws/cloudformation.go
@@ -46,7 +46,7 @@ type CFStack struct {
 }
 
 func (m *CloudformationModule) PrintCloudformationStacks(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "cloudformation"

--- a/aws/codebuild.go
+++ b/aws/codebuild.go
@@ -47,7 +47,7 @@ type Project struct {
 }
 
 func (m *CodeBuildModule) PrintCodeBuildProjects(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "codebuild"

--- a/aws/databases.go
+++ b/aws/databases.go
@@ -53,7 +53,7 @@ type Database struct {
 }
 
 func (m *DatabasesModule) PrintDatabases(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "databases"

--- a/aws/ecr.go
+++ b/aws/ecr.go
@@ -50,7 +50,7 @@ type Repository struct {
 }
 
 func (m *ECRModule) PrintECR(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "ecr"

--- a/aws/eks.go
+++ b/aws/eks.go
@@ -53,7 +53,7 @@ type Cluster struct {
 }
 
 func (m *EKSModule) EKS(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "eks"

--- a/aws/endpoints.go
+++ b/aws/endpoints.go
@@ -84,7 +84,7 @@ type Endpoint struct {
 var oe *smithy.OperationError
 
 func (m *EndpointsModule) PrintEndpoints(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "endpoints"
@@ -615,7 +615,7 @@ func (m *EndpointsModule) getOpenSearchPerRegion(r string, wg *sync.WaitGroup, s
 		var endpoint string
 		var kibana_endpoint string
 
-		// This exits thie function if an opensearch domain exists but there is no endpoint
+		// This exits the function if an opensearch domain exists but there is no endpoint
 		if raw_endpoint == nil {
 			return
 		} else {

--- a/aws/env-vars.go
+++ b/aws/env-vars.go
@@ -66,7 +66,7 @@ type EnvironmentVariable struct {
 }
 
 func (m *EnvsModule) PrintEnvs(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "env-vars"

--- a/aws/filesystems.go
+++ b/aws/filesystems.go
@@ -56,7 +56,7 @@ type FilesystemObject struct {
 }
 
 func (m *FilesystemsModule) PrintFilesystems(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "filesystems"

--- a/aws/iam-simulator.go
+++ b/aws/iam-simulator.go
@@ -66,7 +66,7 @@ var (
 
 func (m *IamSimulatorModule) PrintIamSimulator(principal string, action string, resource string, outputFormat string, outputDirectory string, verbosity int) {
 
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "iam-simulator"

--- a/aws/instances.go
+++ b/aws/instances.go
@@ -64,7 +64,7 @@ type MappedInstance struct {
 }
 
 func (m *InstancesModule) Instances(filter string, outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "instances"

--- a/aws/inventory.go
+++ b/aws/inventory.go
@@ -111,7 +111,7 @@ type GlobalResourceCount2 struct {
 
 func (m *Inventory2Module) PrintInventoryPerRegion(outputFormat string, outputDirectory string, verbosity int) {
 
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "inventory"
@@ -243,7 +243,7 @@ func (m *Inventory2Module) PrintInventoryPerRegion(outputFormat string, outputDi
 	spinnerDone <- true
 	<-spinnerDone
 
-	// This creates the header row (columns) dynamically - a region oly gets printed if it has at least one resource.
+	// This creates the header row (columns) dynamically - a region only gets printed if it has at least one resource.
 	m.output.Headers = append(m.output.Headers, "Resource Type")
 
 	type kv struct {
@@ -311,7 +311,7 @@ func (m *Inventory2Module) PrintInventoryPerRegion(outputFormat string, outputDi
 
 			}
 
-			// check to see if all regions have no resources for the service. Skip the first column, which is hte resource type.
+			// check to see if all regions have no resources for the service. Skip the first column, which is the resource type.
 			// If any value is other than "-" set rowEmpty to false.
 			var rowEmtpy bool = true
 			for _, val := range temprow[1:] {
@@ -322,7 +322,7 @@ func (m *Inventory2Module) PrintInventoryPerRegion(outputFormat string, outputDi
 			}
 			// If rowEmpty is still true at the end of the row, we dont add the row to the output, otherwise we do.
 			if !rowEmtpy {
-				// Convert the slice of strings to a slice of interfaces???  not sure, but this was needed. I couldnt just pass temp row to the output.Body
+				// Convert the slice of strings to a slice of interfaces???  not sure, but this was needed. I couldn't just pass temp row to the output.Body
 				for _, val := range temprow {
 					outputRow = append(outputRow, val)
 

--- a/aws/lambda.go
+++ b/aws/lambda.go
@@ -57,7 +57,7 @@ type Lambda struct {
 
 func (m *LambdasModule) PrintLambdas(outputFormat string, outputDirectory string, verbosity int) {
 
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "lambda"

--- a/aws/network-ports.go
+++ b/aws/network-ports.go
@@ -137,7 +137,7 @@ var naclToSG = map[string]string{
 var validSecurityGroupProtocols = []string{"-1", "tcp", "udp"}
 
 func (m *NetworkPortsModule) PrintNetworkPorts(outputFormat string, outputDirectory string) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = m.Verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "network-ports"

--- a/aws/org.go
+++ b/aws/org.go
@@ -53,7 +53,7 @@ type Account struct {
 }
 
 func (m *OrgModule) PrintOrgAccounts(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	var err error
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
@@ -272,7 +272,7 @@ func (m *OrgModule) addOrgAccount() {
 		isManagementAccount: false,
 		Name:                "This account",
 		Id:                  aws.ToString(m.Caller.Account),
-		Email:               "Unkonwn",
+		Email:               "Unknown",
 		Arn:                 aws.ToString(m.Caller.Arn),
 		Status:              "ACTIVE",
 	})

--- a/aws/outbound-assumed-roles.go
+++ b/aws/outbound-assumed-roles.go
@@ -115,7 +115,7 @@ type CloudTrailEvent struct {
 }
 
 func (m *OutboundAssumedRolesModule) PrintOutboundRoleTrusts(days int, outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "outbound-assumed-roles"

--- a/aws/permissions.go
+++ b/aws/permissions.go
@@ -83,7 +83,7 @@ type PermissionsRow struct {
 }
 
 func (m *IamPermissionsModule) PrintIamPermissions(outputFormat string, outputDirectory string, verbosity int, principal string) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "permissions"

--- a/aws/pmapper.go
+++ b/aws/pmapper.go
@@ -137,7 +137,7 @@ func (m *PmapperModule) DoesPrincipalHaveAdmin(principal string) bool {
 }
 
 func (m *PmapperModule) PrintPmapperData(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "pmapper"

--- a/aws/principals.go
+++ b/aws/principals.go
@@ -62,7 +62,7 @@ type Role struct {
 }
 
 func (m *IamPrincipalsModule) PrintIamPrincipals(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "principals"

--- a/aws/ram.go
+++ b/aws/ram.go
@@ -45,7 +45,7 @@ type Resource struct {
 }
 
 func (m *RAMModule) PrintRAM(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "ram"

--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -47,7 +47,7 @@ type Resource2 struct {
 }
 
 func (m *ResourceTrustsModule) PrintResources(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "resource-trusts"
@@ -270,7 +270,7 @@ func (m *ResourceTrustsModule) getSNSTopicsPerRegion(r string, wg *sync.WaitGrou
 			topic.IsPublic = "No"
 		}
 
-		// If there is a resouce policy, convert the resource policy into plain english
+		// If there is a resource policy, convert the resource policy into plain english
 		if !topic.Policy.IsEmpty() {
 
 			for i, statement := range topic.Policy.Statement {
@@ -357,7 +357,7 @@ func (m *ResourceTrustsModule) getS3Buckets(wg *sync.WaitGroup, semaphore chan s
 			bucket.IsPublic = "No"
 		}
 
-		// If there is a resouce policy, convert the resource policy into plain english
+		// If there is a resource policy, convert the resource policy into plain english
 		if !bucket.Policy.IsEmpty() {
 			for i, statement := range bucket.Policy.Statement {
 				var prefix string = ""

--- a/aws/route53.go
+++ b/aws/route53.go
@@ -43,7 +43,7 @@ type Record struct {
 
 func (m *Route53Module) PrintRoute53(outputFormat string, outputDirectory string, verbosity int) {
 
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "route53"

--- a/aws/sdk/iam.go
+++ b/aws/sdk/iam.go
@@ -207,7 +207,7 @@ func CachedIamSimulatePrincipalPolicy(IAMClient AWSIAMClientInterface, accountID
 	var EvaluationResults []iamTypes.EvaluationResult
 	md5hashedActionNames := md5.Sum([]byte(strings.Join(actionNames, "")))
 	md5hashedResourceArns := md5.Sum([]byte(strings.Join(resourceArns, "")))
-	// proccess arn and get the name of the resource
+	// process arn and get the name of the resource
 	arn, err := arn.Parse(*principal)
 	if err != nil {
 		return EvaluationResults, err

--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -46,7 +46,7 @@ type Secret struct {
 }
 
 func (m *SecretsModule) PrintSecrets(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "secrets"

--- a/aws/sns.go
+++ b/aws/sns.go
@@ -62,7 +62,7 @@ type SNSTopic struct {
 }
 
 func (m *SNSModule) PrintSNS(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "sns"
@@ -288,7 +288,7 @@ func (m *SNSModule) getSNSTopicsPerRegion(r string, wg *sync.WaitGroup, semaphor
 		if !topic.Policy.IsEmpty() {
 			m.analyseTopicPolicy(topic, dataReceiver)
 		} else {
-			// If the topic policy "resource policy" is empty, the only principals that have permisisons
+			// If the topic policy "resource policy" is empty, the only principals that have permissions
 			// are those that are granted access by IAM policies
 			//topic.Access = "Private. Access allowed by IAM policies"
 			topic.Access = "Only intra-account access (via IAM) allowed"

--- a/aws/sqs.go
+++ b/aws/sqs.go
@@ -65,7 +65,7 @@ type Queue struct {
 }
 
 func (m *SQSModule) PrintSQS(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "sqs"
@@ -283,7 +283,7 @@ func (m *SQSModule) getSQSRecordsPerRegion(r string, wg *sync.WaitGroup, semapho
 		if !queue.Policy.IsEmpty() {
 			m.analyseQueuePolicy(queue, dataReceiver)
 		} else {
-			// If the queue policy "resource policy" is empty, the only principals that have permisisons
+			// If the queue policy "resource policy" is empty, the only principals that have permissions
 			// are those that are granted access by IAM policies
 			//queue.Access = "Private. Access allowed by IAM policies"
 			queue.Access = "Only intra-account access (via IAM) allowed"

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -55,7 +55,7 @@ type Tag struct {
 }
 
 func (m *TagsModule) PrintTags(outputFormat string, outputDirectory string, verbosity int) {
-	// These stuct values are used by the output module
+	// These struct values are used by the output module
 	m.output.Verbosity = verbosity
 	m.output.Directory = outputDirectory
 	m.output.CallingModule = "tags"
@@ -284,7 +284,7 @@ func (m *TagsModule) getResources(r string) ([]types.ResourceTagMapping, error) 
 	var PaginationControl *string
 	var resources []types.ResourceTagMapping
 
-	// a for loop that accepts user input. If no user input, it will continue to paginate until there are no mor pages. If there is user input, it will paginate until the user input is reached.
+	// a for loop that accepts user input. If no user input, it will continue to paginate until there are no more pages. If there is user input, it will paginate until the user input is reached.
 
 	for {
 		if len(resources) < m.MaxResourcesPerRegion || m.MaxResourcesPerRegion == 0 {

--- a/azure/shared.go
+++ b/azure/shared.go
@@ -80,7 +80,7 @@ func GetTenantIDPerSubscription(subscriptionID string) *string {
 	return nil
 }
 
-// function that determins if AzSubsriptionType is a subscritpion ID or a subscription display name and returns the AzSubsriptionType struct with both populated
+// function that determines if AzSubsriptionType is a subscription ID or a subscription display name and returns the AzSubsriptionType struct with both populated
 func PopulateSubsriptionType(subscription string) SubsriptionInfo {
 	subs := GetSubscriptions()
 	for _, s := range subs {

--- a/azure/whoami.go
+++ b/azure/whoami.go
@@ -36,7 +36,7 @@ func AzWhoamiCommand(AzOutputDirectory, version string, AzWrapTable bool, AzVerb
 		// cloudfox azure whoami
 		header, body = getWhoamiRelevantDataSubsOnly()
 		o.Table.DirectoryName = filepath.Join(AzOutputDirectory, globals.CLOUDFOX_BASE_DIRECTORY, globals.AZ_DIR_BASE, "whoami-data")
-		// append timetamp to filename (time from epoch)
+		// append timestamp to filename (time from epoch)
 		o.Table.TableFiles = append(o.Table.TableFiles,
 			internal.TableFile{
 				Header: header,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -207,7 +207,7 @@ var (
 	EnvsCommand = &cobra.Command{
 		Use:     "env-vars",
 		Aliases: []string{"envs", "envvars", "env"},
-		Short:   "Enumerate the environment variables from mutliple services that have them",
+		Short:   "Enumerate the environment variables from multiple services that have them",
 		Long: "\nUse case examples:\n" +
 			os.Args[0] + " aws env-vars --profile readonly_profile",
 		PreRun:  awsPreRun,

--- a/internal/aws/policy/condition.go
+++ b/internal/aws/policy/condition.go
@@ -6,7 +6,7 @@ import (
 )
 
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
-// Conditions have the folling general structure:
+// Conditions have the following general structure:
 //   "Condition" : { "{condition-operator}" : { "{condition-key}" : "{condition-value}" }}
 type PolicyStatementCondition map[string]map[string]ListOrString
 
@@ -20,7 +20,7 @@ func (psc *PolicyStatementCondition) IsEmpty() bool {
 
 // IsScopedOnAccountOrOrganization returns true if the policy condition ensures access only for specific
 // AWS accounts or organizations. If may return false even if access is restricted in such a way.
-// Such policies should be reported to the user and analyzed case by case to judge if conditions are sufficently restrictive.
+// Such policies should be reported to the user and analyzed case by case to judge if conditions are sufficiently restrictive.
 func (psc *PolicyStatementCondition) IsScopedOnAccountOrOrganization() bool {
 	for condition, kv := range *psc {
 		for k, v := range kv {

--- a/internal/aws_test.go
+++ b/internal/aws_test.go
@@ -71,7 +71,7 @@ func TestGetSelectedAWSProfiles(t *testing.T) {
 		afero.WriteFile(UtilsFs, "/tmp/myfile.txt", test.fileData, 0755)
 		output := GetSelectedAWSProfiles("/tmp/myfile.txt")
 		if !compareSlice(output, test.expectedOutput) {
-			t.Errorf("Test Failed: %v inputted, %v expected, recieved: %v", test.fileData, test.expectedOutput, output)
+			t.Errorf("Test Failed: %v inputted, %v expected, received: %v", test.fileData, test.expectedOutput, output)
 		}
 	}
 }

--- a/internal/azure_test.go
+++ b/internal/azure_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/BishopFox/cloudfox/globals"
 )
 
-// Requires Az CLI Authentication to passs
+// Requires Az CLI Authentication to pass
 func TestGetAuthorizer(t *testing.T) {
 	t.Skip()
 	subtests := []struct {

--- a/internal/output.go
+++ b/internal/output.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// This struct is here to mantain compatibility with legacy cloudfox code
+// This struct is here to maintain compatibility with legacy cloudfox code
 type OutputData2 struct {
 	Headers       []string
 	Body          [][]string


### PR DESCRIPTION
% `codespell --ignore-words-list=aks`

https://pypi.org/project/codespell