### PR TITLE
Release PR for 1.13.1

### DIFF
--- a/aws/api-gws.go
+++ b/aws/api-gws.go
@@ -12,9 +12,7 @@ import (
 	"github.com/BishopFox/cloudfox/aws/sdk"
 	"github.com/BishopFox/cloudfox/internal"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	apigatewayTypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	apigatewayV2Types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/bishopfox/awsservicemap"
@@ -25,8 +23,8 @@ var CURL_COMMAND string = "curl -X %s %s"
 
 type ApiGwModule struct {
 	// General configuration data
-	APIGatewayClient   *apigateway.Client
-	APIGatewayv2Client *apigatewayv2.Client
+	APIGatewayClient   sdk.APIGatewayClientInterface
+	APIGatewayv2Client sdk.APIGatewayv2ClientInterface
 
 	Caller     sts.GetCallerIdentityOutput
 	AWSRegions []string

--- a/aws/api-gws_test.go
+++ b/aws/api-gws_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BishopFox/cloudfox/aws/sdk"
+	"github.com/BishopFox/cloudfox/internal"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/spf13/afero"
+)
+
+func TestApiGw(t *testing.T) {
+
+	m := ApiGwModule{
+		AWSProfile: "unittesting",
+		AWSRegions: []string{"us-east-1"},
+		Caller: sts.GetCallerIdentityOutput{
+			Arn:     aws.String("arn:aws:iam::123456789012:user/Alice"),
+			Account: aws.String("123456789012"),
+		},
+		Goroutines:         3,
+		WrapTable:          false,
+		APIGatewayClient:   &sdk.MockedAWSAPIGatewayClient{},
+		APIGatewayv2Client: &sdk.MockedAWSAPIGatewayv2Client{},
+	}
+
+	fs := internal.MockFileSystem(true)
+	defer internal.MockFileSystem(false)
+	tmpDir := "~/.cloudfox/"
+
+	m.PrintApiGws(tmpDir, 2)
+
+	resultsFilePath := filepath.Join(tmpDir, "cloudfox-output/aws/unittesting-123456789012/table/api-gw.txt")
+	resultsFile, err := afero.ReadFile(fs, resultsFilePath)
+	if err != nil {
+		t.Fatalf("Cannot read output file at %s: %s", resultsFilePath, err)
+	}
+	//print the results file to the screen
+	fmt.Println(string(resultsFile))
+
+	// I want a test that runs the main function and checks the output to see if the following items are in the output: "https://qwerty.execute-api.us-east-1.amazonaws.com/stage1/path1", "https://asdfsdfasdf.execute-api.us-east-1.amazonaws.com/stage1/route2"
+
+	expectedResults := []string{
+		"https://qwerty.execute-api.us-east-1.amazonaws.com/stage1/path1",
+		"https://asdfsdfasdf.execute-api.us-east-1.amazonaws.com/stage1/route2",
+		"https://asdfsdfasdf.execute-api.us-east-1.amazonaws.com/stage2/route1",
+		"23oieuwefo3rfs",
+	}
+
+	for _, expected := range expectedResults {
+		if !strings.Contains(string(resultsFile), expected) {
+			t.Errorf("Expected %s to be in the results file", expected)
+		}
+	}
+}

--- a/aws/api-gws_test.go
+++ b/aws/api-gws_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,7 +39,7 @@ func TestApiGw(t *testing.T) {
 		t.Fatalf("Cannot read output file at %s: %s", resultsFilePath, err)
 	}
 	//print the results file to the screen
-	fmt.Println(string(resultsFile))
+	//fmt.Println(string(resultsFile))
 
 	// I want a test that runs the main function and checks the output to see if the following items are in the output: "https://qwerty.execute-api.us-east-1.amazonaws.com/stage1/path1", "https://asdfsdfasdf.execute-api.us-east-1.amazonaws.com/stage1/route2"
 

--- a/aws/client-initializers.go
+++ b/aws/client-initializers.go
@@ -20,10 +20,10 @@ import (
 func initIAMSimClient(iamSimPPClient sdk.AWSIAMClientInterface, caller sts.GetCallerIdentityOutput, AWSProfile string, Goroutines int) IamSimulatorModule {
 
 	iamSimMod := IamSimulatorModule{
-		IAMClient:  iamSimPPClient,
-		Caller:     caller,
-		AWSProfile: AWSProfile,
-		Goroutines: Goroutines,
+		IAMClient:          iamSimPPClient,
+		Caller:             caller,
+		AWSProfileProvided: AWSProfile,
+		Goroutines:         Goroutines,
 	}
 
 	return iamSimMod

--- a/aws/instances.go
+++ b/aws/instances.go
@@ -512,6 +512,21 @@ func (m *InstancesModule) loadInstanceData(instance types.Instance, region strin
 
 	if instance.IamInstanceProfile == nil {
 		profile = "NoInstanceProfile"
+		dataReceiver <- MappedInstance{
+			ID:               aws.ToString(instance.InstanceId),
+			Name:             aws.ToString(&name),
+			Arn:              fmt.Sprintf("arn:aws:ec2:%s:%s:instance/%s", region, aws.ToString(m.Caller.Account), aws.ToString(instance.InstanceId)),
+			AvailabilityZone: aws.ToString(instance.Placement.AvailabilityZone),
+			State:            string(instance.State.Name),
+			ExternalIP:       externalIP,
+			PrivateIP:        aws.ToString(instance.PrivateIpAddress),
+			Profile:          profile,
+			Role:             "",
+			Region:           region,
+			Admin:            adminRole,
+			CanPrivEsc:       "",
+		}
+
 	} else {
 		profileArn = aws.ToString(instance.IamInstanceProfile.Arn)
 

--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -13,8 +13,6 @@ import (
 	"github.com/BishopFox/cloudfox/internal/aws/policy"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/aws/aws-sdk-go-v2/service/glue"
-	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/bishopfox/awsservicemap"
 	"github.com/sirupsen/logrus"
@@ -22,16 +20,17 @@ import (
 
 type ResourceTrustsModule struct {
 	// General configuration data
-	Caller          sts.GetCallerIdentityOutput
-	AWSRegions      []string
-	Goroutines      int
-	WrapTable       bool
-	AWSOutputType   string
-	AWSTableCols    string
-	AWSMFAToken     string
-	AWSConfig       aws.Config
-	AWSProfile      string
-	CloudFoxVersion string
+	Caller             sts.GetCallerIdentityOutput
+	AWSRegions         []string
+	Goroutines         int
+	WrapTable          bool
+	AWSOutputType      string
+	AWSTableCols       string
+	AWSMFAToken        string
+	AWSConfig          aws.Config
+	AWSProfileProvided string
+	AWSProfileFake     string
+	CloudFoxVersion    string
 
 	Resources2     []Resource2
 	CommandCounter internal.CommandCounter
@@ -64,13 +63,14 @@ func (m *ResourceTrustsModule) PrintResources(outputDirectory string, verbosity 
 	m.modLog = internal.TxtLog.WithFields(logrus.Fields{
 		"module": m.output.CallingModule,
 	})
-	m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfile, aws.ToString(m.Caller.Account)))
-	if m.AWSProfile == "" {
-		m.AWSProfile = internal.BuildAWSPath(m.Caller)
-	}
 
-	fmt.Printf("[%s][%s] Enumerating Resources with resource policies for account %s.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), aws.ToString(m.Caller.Account))
-	fmt.Printf("[%s][%s] Supported Services: CodeBuild, ECR, EFS, Glue, Lambda, SecretsManager, S3, SNS, SQS\n", cyan(m.output.CallingModule), cyan(m.AWSProfile))
+	if m.AWSProfileProvided == "" {
+		m.AWSProfileFake = internal.BuildAWSPath(m.Caller)
+	}
+	m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfileProvided, aws.ToString(m.Caller.Account)))
+
+	fmt.Printf("[%s][%s] Enumerating Resources with resource policies for account %s.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake), aws.ToString(m.Caller.Account))
+	fmt.Printf("[%s][%s] Supported Services: CodeBuild, ECR, EFS, Glue, Lambda, SecretsManager, S3, SNS, SQS\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake))
 	wg := new(sync.WaitGroup)
 	semaphore := make(chan struct{}, m.Goroutines)
 
@@ -174,16 +174,16 @@ func (m *ResourceTrustsModule) PrintResources(outputDirectory string, verbosity 
 			TableCols: tableCols,
 			Name:      m.output.CallingModule,
 		})
-		o.PrefixIdentifier = m.AWSProfile
-		o.Table.DirectoryName = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfile, aws.ToString(m.Caller.Account)))
+		o.PrefixIdentifier = m.AWSProfileFake
+		o.Table.DirectoryName = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfileFake, aws.ToString(m.Caller.Account)))
 		o.WriteFullOutput(o.Table.TableFiles, nil)
 		//m.writeLoot(o.Table.DirectoryName, verbosity)
-		fmt.Printf("[%s][%s] %s resource policies found.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), strconv.Itoa(len(m.output.Body)))
+		fmt.Printf("[%s][%s] %s resource policies found.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake), strconv.Itoa(len(m.output.Body)))
 		//fmt.Printf("[%s][%s] Resource policies stored to: %s\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), m.getLootDir())
 	} else {
-		fmt.Printf("[%s][%s] No resource policies found, skipping the creation of an output file.\n", cyan(m.output.CallingModule), cyan(m.AWSProfile))
+		fmt.Printf("[%s][%s] No resource policies found, skipping the creation of an output file.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake))
 	}
-	fmt.Printf("[%s][%s] For context and next steps: https://github.com/BishopFox/cloudfox/wiki/AWS-Commands#%s\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), m.output.CallingModule)
+	fmt.Printf("[%s][%s] For context and next steps: https://github.com/BishopFox/cloudfox/wiki/AWS-Commands#%s\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake), m.output.CallingModule)
 
 }
 
@@ -294,13 +294,7 @@ func (m *ResourceTrustsModule) getSNSTopicsPerRegion(r string, wg *sync.WaitGrou
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxSNSClient SNSModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxSNSClient = InitCloudFoxSNSClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.WrapTable, m.AWSMFAToken)
-	} else {
-		cloudFoxSNSClient = InitCloudFoxSNSClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.WrapTable, m.AWSMFAToken)
-	}
+	cloudFoxSNSClient := InitCloudFoxSNSClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.WrapTable, m.AWSMFAToken)
 
 	ListTopics, err := cloudFoxSNSClient.listTopics(r)
 	if err != nil {
@@ -376,13 +370,7 @@ func (m *ResourceTrustsModule) getS3Buckets(wg *sync.WaitGroup, semaphore chan s
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxS3Client BucketsModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxS3Client = initCloudFoxS3Client(m.Caller, "", m.CloudFoxVersion, m.AWSMFAToken)
-	} else {
-		cloudFoxS3Client = initCloudFoxS3Client(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.AWSMFAToken)
-	}
+	cloudFoxS3Client := initCloudFoxS3Client(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.AWSMFAToken)
 
 	ListBuckets, err := sdk.CachedListBuckets(cloudFoxS3Client.S3Client, aws.ToString(m.Caller.Account))
 	if err != nil {
@@ -465,13 +453,7 @@ func (m *ResourceTrustsModule) getSQSQueuesPerRegion(r string, wg *sync.WaitGrou
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxSQSClient SQSModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxSQSClient = InitSQSClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxSQSClient = InitSQSClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxSQSClient := InitSQSClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	ListQueues, err := cloudFoxSQSClient.listQueues(r)
 	if err != nil {
@@ -533,13 +515,7 @@ func (m *ResourceTrustsModule) getECRRecordsPerRegion(r string, wg *sync.WaitGro
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxECRClient ECRModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxECRClient = InitECRClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxECRClient = InitECRClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxECRClient := InitECRClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	DescribeRepositories, err := sdk.CachedECRDescribeRepositories(cloudFoxECRClient.ECRClient, aws.ToString(m.Caller.Account), r)
 	if err != nil {
@@ -603,13 +579,7 @@ func (m *ResourceTrustsModule) getCodeBuildResourcePoliciesPerRegion(r string, w
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxCodeBuildClient CodeBuildModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxCodeBuildClient = InitCodeBuildClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxCodeBuildClient = InitCodeBuildClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxCodeBuildClient := InitCodeBuildClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	ListProjects, err := sdk.CachedCodeBuildListProjects(cloudFoxCodeBuildClient.CodeBuildClient, aws.ToString(cloudFoxCodeBuildClient.Caller.Account), r)
 	if err != nil {
@@ -683,13 +653,7 @@ func (m *ResourceTrustsModule) getLambdaPolicyPerRegion(r string, wg *sync.WaitG
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxLambdaClient LambdasModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxLambdaClient = InitLambdaClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxLambdaClient = InitLambdaClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxLambdaClient := InitLambdaClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	ListFunctions, err := cloudFoxLambdaClient.listFunctions(r)
 	if err != nil {
@@ -754,13 +718,7 @@ func (m *ResourceTrustsModule) getEFSfilesystemPoliciesPerRegion(r string, wg *s
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxEFSClient FilesystemsModule
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxEFSClient = InitFileSystemsClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxEFSClient = InitFileSystemsClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxEFSClient := InitFileSystemsClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	ListFileSystems, err := sdk.CachedDescribeFileSystems(cloudFoxEFSClient.EFSClient, aws.ToString(m.Caller.Account), r)
 	if err != nil {
@@ -830,13 +788,7 @@ func (m *ResourceTrustsModule) getSecretsManagerSecretsPoliciesPerRegion(r strin
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxSecretsManagerClient *secretsmanager.Client
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxSecretsManagerClient = InitSecretsManagerClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxSecretsManagerClient = InitSecretsManagerClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxSecretsManagerClient := InitSecretsManagerClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	ListSecrets, err := sdk.CachedSecretsManagerListSecrets(cloudFoxSecretsManagerClient, aws.ToString(m.Caller.Account), r)
 	if err != nil {
@@ -902,13 +854,7 @@ func (m *ResourceTrustsModule) getGlueResourcePoliciesPerRegion(r string, wg *sy
 	semaphore <- struct{}{}
 	defer func() { <-semaphore }()
 
-	var cloudFoxGlueClient *glue.Client
-
-	if strings.Contains(m.AWSProfile, "-AROA") {
-		cloudFoxGlueClient = InitGlueClient(m.Caller, "", m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	} else {
-		cloudFoxGlueClient = InitGlueClient(m.Caller, m.AWSProfile, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
-	}
+	cloudFoxGlueClient := InitGlueClient(m.Caller, m.AWSProfileProvided, m.CloudFoxVersion, m.Goroutines, m.AWSMFAToken)
 
 	ResourcePolicies, err := sdk.CachedGlueGetResourcePolicies(cloudFoxGlueClient, aws.ToString(m.Caller.Account), r)
 	if err != nil {

--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -29,7 +29,7 @@ type ResourceTrustsModule struct {
 	AWSMFAToken        string
 	AWSConfig          aws.Config
 	AWSProfileProvided string
-	AWSProfileFake     string
+	AWSProfileStub     string
 	CloudFoxVersion    string
 
 	Resources2     []Resource2
@@ -65,12 +65,14 @@ func (m *ResourceTrustsModule) PrintResources(outputDirectory string, verbosity 
 	})
 
 	if m.AWSProfileProvided == "" {
-		m.AWSProfileFake = internal.BuildAWSPath(m.Caller)
+		m.AWSProfileStub = internal.BuildAWSPath(m.Caller)
+	} else {
+		m.AWSProfileStub = m.AWSProfileProvided
 	}
 	m.output.FilePath = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfileProvided, aws.ToString(m.Caller.Account)))
 
-	fmt.Printf("[%s][%s] Enumerating Resources with resource policies for account %s.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake), aws.ToString(m.Caller.Account))
-	fmt.Printf("[%s][%s] Supported Services: CodeBuild, ECR, EFS, Glue, Lambda, SecretsManager, S3, SNS, SQS\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake))
+	fmt.Printf("[%s][%s] Enumerating Resources with resource policies for account %s.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileStub), aws.ToString(m.Caller.Account))
+	fmt.Printf("[%s][%s] Supported Services: CodeBuild, ECR, EFS, Glue, Lambda, SecretsManager, S3, SNS, SQS\n", cyan(m.output.CallingModule), cyan(m.AWSProfileStub))
 	wg := new(sync.WaitGroup)
 	semaphore := make(chan struct{}, m.Goroutines)
 
@@ -174,16 +176,16 @@ func (m *ResourceTrustsModule) PrintResources(outputDirectory string, verbosity 
 			TableCols: tableCols,
 			Name:      m.output.CallingModule,
 		})
-		o.PrefixIdentifier = m.AWSProfileFake
-		o.Table.DirectoryName = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfileFake, aws.ToString(m.Caller.Account)))
+		o.PrefixIdentifier = m.AWSProfileStub
+		o.Table.DirectoryName = filepath.Join(outputDirectory, "cloudfox-output", "aws", fmt.Sprintf("%s-%s", m.AWSProfileStub, aws.ToString(m.Caller.Account)))
 		o.WriteFullOutput(o.Table.TableFiles, nil)
 		//m.writeLoot(o.Table.DirectoryName, verbosity)
-		fmt.Printf("[%s][%s] %s resource policies found.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake), strconv.Itoa(len(m.output.Body)))
+		fmt.Printf("[%s][%s] %s resource policies found.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileStub), strconv.Itoa(len(m.output.Body)))
 		//fmt.Printf("[%s][%s] Resource policies stored to: %s\n", cyan(m.output.CallingModule), cyan(m.AWSProfile), m.getLootDir())
 	} else {
-		fmt.Printf("[%s][%s] No resource policies found, skipping the creation of an output file.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake))
+		fmt.Printf("[%s][%s] No resource policies found, skipping the creation of an output file.\n", cyan(m.output.CallingModule), cyan(m.AWSProfileStub))
 	}
-	fmt.Printf("[%s][%s] For context and next steps: https://github.com/BishopFox/cloudfox/wiki/AWS-Commands#%s\n", cyan(m.output.CallingModule), cyan(m.AWSProfileFake), m.output.CallingModule)
+	fmt.Printf("[%s][%s] For context and next steps: https://github.com/BishopFox/cloudfox/wiki/AWS-Commands#%s\n", cyan(m.output.CallingModule), cyan(m.AWSProfileStub), m.output.CallingModule)
 
 }
 

--- a/aws/sdk/apigateway_mocks.go
+++ b/aws/sdk/apigateway_mocks.go
@@ -15,12 +15,127 @@ func (m *MockedAWSAPIGatewayClient) GetRestApis(ctx context.Context, input *apig
 	return &apigateway.GetRestApisOutput{
 		Items: []apiGatewayTypes.RestApi{
 			{
-				Id:   aws.String("api1"),
+				Id:   aws.String("abcdefg"),
 				Name: aws.String("api1"),
+				EndpointConfiguration: &apiGatewayTypes.EndpointConfiguration{
+					Types: []apiGatewayTypes.EndpointType{
+						apiGatewayTypes.EndpointTypePrivate,
+					},
+				},
 			},
 			{
-				Id:   aws.String("api2"),
+				Id:   aws.String("qwerty"),
 				Name: aws.String("api2"),
+				EndpointConfiguration: &apiGatewayTypes.EndpointConfiguration{
+					Types: []apiGatewayTypes.EndpointType{
+						apiGatewayTypes.EndpointTypeRegional,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetStages(ctx context.Context, input *apigateway.GetStagesInput, options ...func(*apigateway.Options)) (*apigateway.GetStagesOutput, error) {
+	return &apigateway.GetStagesOutput{
+		Item: []apiGatewayTypes.Stage{
+			{
+				StageName: aws.String("stage1"),
+			},
+			{
+				StageName: aws.String("stage2"),
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetResources(ctx context.Context, input *apigateway.GetResourcesInput, options ...func(*apigateway.Options)) (*apigateway.GetResourcesOutput, error) {
+	return &apigateway.GetResourcesOutput{
+		Items: []apiGatewayTypes.Resource{
+			{
+				Id:   aws.String("resource1"),
+				Path: aws.String("/path1"),
+				ResourceMethods: map[string]apiGatewayTypes.Method{
+					"GET": {
+						ApiKeyRequired: aws.Bool(true),
+						AuthorizerId:   aws.String("authorizer1"),
+						OperationName:  aws.String("operation1"),
+					},
+				},
+			},
+			{
+				Id:   aws.String("resource2"),
+				Path: aws.String("/path2"),
+				ResourceMethods: map[string]apiGatewayTypes.Method{
+					"ANY": {
+						ApiKeyRequired: aws.Bool(true),
+						AuthorizerId:   aws.String("authorizer2"),
+						OperationName:  aws.String("operation2"),
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetDomainNames(ctx context.Context, input *apigateway.GetDomainNamesInput, options ...func(*apigateway.Options)) (*apigateway.GetDomainNamesOutput, error) {
+	return &apigateway.GetDomainNamesOutput{
+		Items: []apiGatewayTypes.DomainName{},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetBasePathMappings(ctx context.Context, input *apigateway.GetBasePathMappingsInput, options ...func(*apigateway.Options)) (*apigateway.GetBasePathMappingsOutput, error) {
+	return &apigateway.GetBasePathMappingsOutput{
+		Items: []apiGatewayTypes.BasePathMapping{
+			{
+				BasePath:  aws.String("basepath1"),
+				RestApiId: aws.String("abcdefg"),
+				Stage:     aws.String("stage1"),
+			},
+			{
+				BasePath:  aws.String("basepath2"),
+				RestApiId: aws.String("qwerty"),
+				Stage:     aws.String("stage2"),
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetMethod(ctx context.Context, input *apigateway.GetMethodInput, options ...func(*apigateway.Options)) (*apigateway.GetMethodOutput, error) {
+	return &apigateway.GetMethodOutput{
+		ApiKeyRequired: aws.Bool(true),
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetUsagePlans(ctx context.Context, input *apigateway.GetUsagePlansInput, options ...func(*apigateway.Options)) (*apigateway.GetUsagePlansOutput, error) {
+	return &apigateway.GetUsagePlansOutput{
+		Items: []apiGatewayTypes.UsagePlan{
+			{
+				Id:   aws.String("usageplan1"),
+				Name: aws.String("usageplan1"),
+				ApiStages: []apiGatewayTypes.ApiStage{
+					{
+						ApiId: aws.String("abcdefg"),
+						Stage: aws.String("stage2"),
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayClient) GetUsagePlanKeys(ctx context.Context, input *apigateway.GetUsagePlanKeysInput, options ...func(*apigateway.Options)) (*apigateway.GetUsagePlanKeysOutput, error) {
+	return &apigateway.GetUsagePlanKeysOutput{
+		Items: []apiGatewayTypes.UsagePlanKey{
+			{
+				Id:    aws.String("usageplankey1"),
+				Type:  aws.String("API_KEY"),
+				Value: aws.String("23oieuwefo3rfs"),
+			},
+			{
+				Id:    aws.String("usageplankey2"),
+				Type:  aws.String("API_KEY"),
+				Value: aws.String("982yf98fdv8dlds"),
 			},
 		},
 	}, nil

--- a/aws/sdk/apigatewayv2_mocks.go
+++ b/aws/sdk/apigatewayv2_mocks.go
@@ -15,12 +15,68 @@ func (m *MockedAWSAPIGatewayv2Client) GetApis(ctx context.Context, input *apigat
 	return &apigatewayv2.GetApisOutput{
 		Items: []apiGatwayV2Types.Api{
 			{
-				ApiId: aws.String("api1"),
-				Name:  aws.String("api1"),
+				ApiId:       aws.String("asdfsdfasdf"),
+				Name:        aws.String("api1"),
+				ApiEndpoint: aws.String("https://asdfsdfasdf.execute-api.us-east-1.amazonaws.com"),
 			},
 			{
-				ApiId: aws.String("api2"),
-				Name:  aws.String("api2"),
+				ApiId:       aws.String("qwertyqwerty"),
+				Name:        aws.String("api2"),
+				ApiEndpoint: aws.String("https://qwertyqwerty.execute-api.us-east-1.amazonaws.com"),
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayv2Client) GetDomainNames(ctx context.Context, input *apigatewayv2.GetDomainNamesInput, options ...func(*apigatewayv2.Options)) (*apigatewayv2.GetDomainNamesOutput, error) {
+	return &apigatewayv2.GetDomainNamesOutput{
+		Items: []apiGatwayV2Types.DomainName{
+			{
+				DomainName: aws.String("domain1"),
+			},
+			{
+				DomainName: aws.String("domain2"),
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayv2Client) GetApiMappings(ctx context.Context, input *apigatewayv2.GetApiMappingsInput, options ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApiMappingsOutput, error) {
+	return &apigatewayv2.GetApiMappingsOutput{
+		Items: []apiGatwayV2Types.ApiMapping{
+			{
+				ApiMappingId: aws.String("apiMapping1"),
+			},
+			{
+				ApiMappingId: aws.String("apiMapping2"),
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayv2Client) GetStages(ctx context.Context, input *apigatewayv2.GetStagesInput, options ...func(*apigatewayv2.Options)) (*apigatewayv2.GetStagesOutput, error) {
+	return &apigatewayv2.GetStagesOutput{
+		Items: []apiGatwayV2Types.Stage{
+			{
+				StageName: aws.String("stage1"),
+			},
+			{
+				StageName: aws.String("stage2"),
+			},
+		},
+	}, nil
+}
+
+func (m *MockedAWSAPIGatewayv2Client) GetRoutes(ctx context.Context, input *apigatewayv2.GetRoutesInput, options ...func(*apigatewayv2.Options)) (*apigatewayv2.GetRoutesOutput, error) {
+	return &apigatewayv2.GetRoutesOutput{
+		Items: []apiGatwayV2Types.Route{
+			{
+				RouteId:  aws.String("route1"),
+				RouteKey: aws.String("POST /route1"),
+			},
+			{
+				RouteId:  aws.String("route2"),
+				RouteKey: aws.String("GET /route2"),
 			},
 		},
 	}, nil

--- a/aws/sdk/codebuild.go
+++ b/aws/sdk/codebuild.go
@@ -87,7 +87,7 @@ func CachedCodeBuildBatchGetProjects(CodeBuildClient CodeBuildClientInterface, a
 		return project, err
 	}
 
-	internal.Cache.Set(cacheKey, BatchGetProjects.Projects[0], cache.DefaultExpiration)
+	internal.Cache.Set(cacheKey, BatchGetProjects.Projects, cache.DefaultExpiration)
 	return BatchGetProjects.Projects[0], nil
 }
 

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1175,15 +1175,15 @@ func runResourceTrustsCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		m := aws.ResourceTrustsModule{
-			Caller:          *caller,
-			AWSProfile:      profile,
-			Goroutines:      Goroutines,
-			AWSRegions:      internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			WrapTable:       AWSWrapTable,
-			CloudFoxVersion: cmd.Root().Version,
-			AWSOutputType:   AWSOutputType,
-			AWSTableCols:    AWSTableCols,
-			AWSConfig:       AWSConfig,
+			Caller:             *caller,
+			AWSProfileProvided: profile,
+			Goroutines:         Goroutines,
+			AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			WrapTable:          AWSWrapTable,
+			CloudFoxVersion:    cmd.Root().Version,
+			AWSOutputType:      AWSOutputType,
+			AWSTableCols:       AWSTableCols,
+			AWSConfig:          AWSConfig,
 		}
 		m.PrintResources(AWSOutputDirectory, Verbosity)
 	}
@@ -1802,15 +1802,16 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		cloudFoxSNSClient.PrintSNS(AWSOutputDirectory, Verbosity)
 
 		resourceTrustsCommand := aws.ResourceTrustsModule{
-			Caller:          *caller,
-			AWSProfile:      profile,
-			Goroutines:      Goroutines,
-			AWSRegions:      internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
-			WrapTable:       AWSWrapTable,
-			CloudFoxVersion: cmd.Root().Version,
-			AWSOutputType:   AWSOutputType,
-			AWSTableCols:    AWSTableCols,
-			AWSMFAToken:     AWSMFAToken,
+			Caller:             *caller,
+			AWSProfileProvided: profile,
+			Goroutines:         Goroutines,
+			AWSRegions:         internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			WrapTable:          AWSWrapTable,
+			CloudFoxVersion:    cmd.Root().Version,
+			AWSOutputType:      AWSOutputType,
+			AWSTableCols:       AWSTableCols,
+			AWSMFAToken:        AWSMFAToken,
+			AWSConfig:          AWSConfig,
 		}
 		resourceTrustsCommand.PrintResources(AWSOutputDirectory, Verbosity)
 

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -927,13 +927,13 @@ func runIamSimulatorCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		m := aws.IamSimulatorModule{
-			IAMClient:     iam.NewFromConfig(AWSConfig),
-			Caller:        *caller,
-			AWSProfile:    profile,
-			Goroutines:    Goroutines,
-			WrapTable:     AWSWrapTable,
-			AWSOutputType: AWSOutputType,
-			AWSTableCols:  AWSTableCols,
+			IAMClient:          iam.NewFromConfig(AWSConfig),
+			Caller:             *caller,
+			AWSProfileProvided: profile,
+			Goroutines:         Goroutines,
+			WrapTable:          AWSWrapTable,
+			AWSOutputType:      AWSOutputType,
+			AWSTableCols:       AWSTableCols,
 		}
 		m.PrintIamSimulator(SimulatorPrincipal, SimulatorAction, SimulatorResource, AWSOutputDirectory, Verbosity)
 	}
@@ -1881,13 +1881,13 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		pmapperCommand.PrintPmapperData(AWSOutputDirectory, Verbosity)
 
 		iamSimulator := aws.IamSimulatorModule{
-			IAMClient:     iamClient,
-			Caller:        *caller,
-			AWSProfile:    profile,
-			Goroutines:    Goroutines,
-			WrapTable:     AWSWrapTable,
-			AWSOutputType: AWSOutputType,
-			AWSTableCols:  AWSTableCols,
+			IAMClient:          iamClient,
+			Caller:             *caller,
+			AWSProfileProvided: profile,
+			Goroutines:         Goroutines,
+			WrapTable:          AWSWrapTable,
+			AWSOutputType:      AWSOutputType,
+			AWSTableCols:       AWSTableCols,
 		}
 		iamSimulator.PrintIamSimulator(SimulatorPrincipal, SimulatorAction, SimulatorResource, AWSOutputDirectory, Verbosity)
 

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -448,7 +448,7 @@ var (
 
 		Use:     "pmapper",
 		Aliases: []string{"Pmapper", "pmapperParse"},
-		Short:   "",
+		Short:   "Looks for pmapper data for the account and builds a PrivEsc graph in golang if it exists.",
 		Long: "\nUse case examples:\n" +
 			os.Args[0] + " aws ",
 		PreRun:  awsPreRun,

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1169,6 +1169,7 @@ func runRAMCommand(cmd *cobra.Command, args []string) {
 
 func runResourceTrustsCommand(cmd *cobra.Command, args []string) {
 	for _, profile := range AWSProfiles {
+		var AWSConfig = internal.AWSConfigFileLoader(profile, cmd.Root().Version, AWSMFAToken)
 		caller, err := internal.AWSWhoami(profile, cmd.Root().Version, AWSMFAToken)
 		if err != nil {
 			continue
@@ -1182,6 +1183,7 @@ func runResourceTrustsCommand(cmd *cobra.Command, args []string) {
 			CloudFoxVersion: cmd.Root().Version,
 			AWSOutputType:   AWSOutputType,
 			AWSTableCols:    AWSTableCols,
+			AWSConfig:       AWSConfig,
 		}
 		m.PrintResources(AWSOutputDirectory, Verbosity)
 	}

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -1888,6 +1888,23 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 		}
 		iamSimulator.PrintIamSimulator(SimulatorPrincipal, SimulatorAction, SimulatorResource, AWSOutputDirectory, Verbosity)
 
+		workloads := aws.WorkloadsModule{
+			ECSClient:       ecsClient,
+			EC2Client:       ec2Client,
+			LambdaClient:    lambdaClient,
+			AppRunnerClient: appRunnerClient,
+			IAMClient:       iamClient,
+			Caller:          *caller,
+			AWSRegions:      internal.GetEnabledRegions(profile, cmd.Root().Version, AWSMFAToken),
+			SkipAdminCheck:  AWSSkipAdminCheck,
+			AWSProfile:      profile,
+			Goroutines:      Goroutines,
+			WrapTable:       AWSWrapTable,
+			AWSOutputType:   AWSOutputType,
+			AWSTableCols:    AWSTableCols,
+		}
+		workloads.PrintWorkloads(AWSOutputDirectory, Verbosity)
+
 		fmt.Printf("[%s] %s\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("That's it! Check your output files for situational awareness and check your loot files for next steps."))
 		fmt.Printf("[%s] %s\n\n", cyan(emoji.Sprintf(":fox:cloudfox :fox:")), green("FYI, we skipped the outbound-assumed-roles module in all-checks (really long run time). Make sure to try it out manually."))
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BishopFox/cloudfox
 
-go 1.20
+go 1.21.2
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
@@ -63,7 +63,11 @@ require (
 	golang.org/x/crypto v0.17.0
 )
 
-require github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
+require (
+	github.com/bishopfox/knownawsaccountslookup v0.0.0-20231228165844-c37ef8df33cb // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
 github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/bishopfox/awsservicemap v1.0.3 h1:0T+mJLwG+vQV9+o3dzwzxhWJWE40VpoCLWtaPBwixYc=
 github.com/bishopfox/awsservicemap v1.0.3/go.mod h1:oy9Fyqh6AozQjShSx+zRNouTlp7k3z3YEMoFkN8rquc=
+github.com/bishopfox/knownawsaccountslookup v0.0.0-20231228165844-c37ef8df33cb h1:ot96tC/kdm0GKV1kl+aXJorqJbyx92R9bjRQvbBmLKU=
+github.com/bishopfox/knownawsaccountslookup v0.0.0-20231228165844-c37ef8df33cb/go.mod h1:2OnSqu4B86+2xGSIE5D4z3Rze9yJ/LNNjNXHhwMR+vY=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -317,6 +319,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/aws.go
+++ b/internal/aws.go
@@ -60,15 +60,22 @@ func AWSConfigFileLoader(AWSProfile string, version string, AwsMfaToken string) 
 		}
 
 		if err != nil {
-			fmt.Println(err)
-			TxtLog.Println(err)
+			//fmt.Println(err)
+			if AWSProfile != "" {
+				TxtLog.Println(err)
+				fmt.Printf("[%s][%s] The specified profile [%s] does not exist or there was an error loading the credentials.\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)), cyan(AWSProfile), AWSProfile)
+				TxtLog.Fatalf("Could not retrieve the specified profile name %s", err)
+			} else {
+				fmt.Printf("[%s][%s] Error retrieving credentials from environment variables, or the instance metadata service.\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)), cyan(AWSProfile))
+				TxtLog.Fatalf("Error retrieving credentials from environment variables, or the instance metadata service.\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)), cyan(AWSProfile))
+			}
+			//os.Exit(1)
 		}
 
 		_, err := cfg.Credentials.Retrieve(context.TODO())
 
 		if err != nil {
 			fmt.Printf("[%s][%s] Error retrieving credentials from environment variables, or the instance metadata service.\n", cyan(emoji.Sprintf(":fox:cloudfox v%s :fox:", version)), cyan(AWSProfile))
-			TxtLog.Printf("Could not retrieve the specified profile name %s", err)
 
 		} else {
 			// update the config map with the new config for future lookups

--- a/internal/output2.go
+++ b/internal/output2.go
@@ -144,8 +144,11 @@ func (l *LootClient) createLootFiles(lootFiles []LootFile) {
 		if l.DirectoryName == "" {
 			l.DirectoryName = "."
 		}
-		if _, err := fileSystem.Stat(l.DirectoryName); os.IsNotExist(err) {
-			err = fileSystem.MkdirAll(l.DirectoryName, 0700)
+
+		lootDirectory := path.Join(l.DirectoryName, "loot")
+
+		if _, err := fileSystem.Stat(lootDirectory); os.IsNotExist(err) {
+			err = fileSystem.MkdirAll(lootDirectory, 0700)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -156,7 +159,7 @@ func (l *LootClient) createLootFiles(lootFiles []LootFile) {
 
 		l.LootFiles[i].Name = fmt.Sprintf("%s.txt", file.Name)
 
-		filePointer, err := fileSystem.OpenFile(path.Join(l.DirectoryName, l.LootFiles[i].Name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		filePointer, err := fileSystem.OpenFile(path.Join(lootDirectory, l.LootFiles[i].Name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			log.Fatalf("error creating output file: %s", err)
 		}
@@ -169,7 +172,7 @@ func (l *LootClient) writeLootFiles() []string {
 	var fullFilePaths []string
 	for _, file := range l.LootFiles {
 		contents := []byte(file.Contents)
-		fullPath := path.Join(l.DirectoryName, file.Name)
+		fullPath := path.Join(l.DirectoryName, "loot", file.Name)
 
 		err := os.WriteFile(fullPath, contents, 0644)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:     os.Args[0],
-		Version: "1.13.0",
+		Version: "1.13.1-prerelease",
 	}
 )
 


### PR DESCRIPTION
Fixes: 

* Added `workloads` to `all-checks` -- forgot that in 1.13.0
* Added data from fwd:cloudsec's `known_aws_accounts` repo into the `role-trusts` module
* Fixed bug where `resource-trusts` was calling `all-checks` to crash if you did not use a named profile
* Fixed bug in `CachedCodeBuildBatchGetProjects` in the sdk package
* Fixed bug in `iam-simulator` command so that generated pmapper commands would not contain the --profile flag if the user did not use a profile to run cloudfox


