### PR TITLE
Version 1.13.2 - 2 bug fixes on new functionality in 1.13.1

### DIFF
--- a/aws/env-vars.go
+++ b/aws/env-vars.go
@@ -836,7 +836,7 @@ func (m *EnvsModule) interestingEnvVarsOnly() [][]string {
 	for _, envVar := range m.EnvironmentVariables {
 		if envVar.interesting {
 			interestingBody = append(
-				m.output.Body, []string{
+				interestingBody, []string{
 					aws.ToString(m.Caller.Account),
 					envVar.service,
 					envVar.region,

--- a/aws/role-trusts.go
+++ b/aws/role-trusts.go
@@ -241,33 +241,32 @@ func (m *RoleTrustsModule) printPrincipalTrusts(outputDirectory string) ([]strin
 	for _, role := range m.AnalyzedRoles {
 		for _, statement := range role.trustsDoc.Statement {
 			for _, principal := range statement.Principal.AWS {
-				if strings.Contains(principal, ":root") {
-					//check to see if the accountID is known
-					accountID := strings.Split(principal, ":")[4]
-					vendorName := m.vendors.GetVendorNameFromAccountID(accountID)
-					if vendorName != "" {
-						principal = fmt.Sprintf("%s (%s)", principal, vendorName)
-					}
-
-					RoleTrustRow := RoleTrustRow{
-						RoleARN:          aws.ToString(role.roleARN),
-						RoleName:         GetResourceNameFromArn(aws.ToString(role.roleARN)),
-						TrustedPrincipal: principal,
-						ExternalID:       statement.Condition.StringEquals.StsExternalID,
-						IsAdmin:          role.Admin,
-						CanPrivEsc:       role.CanPrivEsc,
-					}
-					body = append(body, []string{
-						aws.ToString(m.Caller.Account),
-						RoleTrustRow.RoleARN,
-						RoleTrustRow.RoleName,
-						RoleTrustRow.TrustedPrincipal,
-						RoleTrustRow.ExternalID,
-						RoleTrustRow.IsAdmin,
-						RoleTrustRow.CanPrivEsc})
+				//check to see if the accountID is known
+				accountID := strings.Split(principal, ":")[4]
+				vendorName := m.vendors.GetVendorNameFromAccountID(accountID)
+				if vendorName != "" {
+					principal = fmt.Sprintf("%s (%s)", principal, vendorName)
 				}
+
+				RoleTrustRow := RoleTrustRow{
+					RoleARN:          aws.ToString(role.roleARN),
+					RoleName:         GetResourceNameFromArn(aws.ToString(role.roleARN)),
+					TrustedPrincipal: principal,
+					ExternalID:       statement.Condition.StringEquals.StsExternalID,
+					IsAdmin:          role.Admin,
+					CanPrivEsc:       role.CanPrivEsc,
+				}
+				body = append(body, []string{
+					aws.ToString(m.Caller.Account),
+					RoleTrustRow.RoleARN,
+					RoleTrustRow.RoleName,
+					RoleTrustRow.TrustedPrincipal,
+					RoleTrustRow.ExternalID,
+					RoleTrustRow.IsAdmin,
+					RoleTrustRow.CanPrivEsc})
 			}
 		}
+
 	}
 
 	m.sortTrustsTablePerTrustedPrincipal()

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:     os.Args[0],
-		Version: "1.13.1-prerelease",
+		Version: "1.13.1",
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:     os.Args[0],
-		Version: "1.13.1",
+		Version: "1.13.2",
 	}
 )
 


### PR DESCRIPTION
Bug fixes: 

* Fixed bug in the role trusts command introduced in 1.13.1 where cloudfox only shows princiapls with :root trust and not ALL role trusts
* Fixed bug in env-vars command introduced in 1.13.1 with the new interesting version of the table written to disk. was still recording them all. now the second table only has interesting env-vars
