### PR TITLE
AWS Route53 Alias Record Support

### DIFF
--- a/aws/route53.go
+++ b/aws/route53.go
@@ -235,19 +235,19 @@ func (m *Route53Module) getRoute53Records() {
 			recordName = aws.ToString(record.Name)
 			recordType = string(record.Type)
 
-			for _, resourceRecord := range record.ResourceRecords {
-				recordValue := resourceRecord.Value
-				if record.AliasTarget != nil {
-					m.Records = append(
-						m.Records,
-						Record{
-							AWSService:  "Route53",
-							Name:        recordName,
-							Type:        fmt.Sprintf("Alias[%s]", recordType),
-							Value:       aws.ToString(record.AliasTarget.DNSName),
-							PrivateZone: privateZone,
-						})
-				} else {
+			if record.AliasTarget != nil {
+				m.Records = append(
+					m.Records,
+					Record{
+						AWSService:  "Route53",
+						Name:        recordName,
+						Type:        fmt.Sprintf("Alias[%s]", recordType),
+						Value:       aws.ToString(record.AliasTarget.DNSName),
+						PrivateZone: privateZone,
+					})
+			} else {
+				for _, resourceRecord := range record.ResourceRecords {
+					recordValue := resourceRecord.Value
 					m.Records = append(
 						m.Records,
 						Record{
@@ -258,8 +258,8 @@ func (m *Route53Module) getRoute53Records() {
 							PrivateZone: privateZone,
 						})
 				}
-
 			}
+
 		}
 
 	}

--- a/aws/route53.go
+++ b/aws/route53.go
@@ -237,15 +237,27 @@ func (m *Route53Module) getRoute53Records() {
 
 			for _, resourceRecord := range record.ResourceRecords {
 				recordValue := resourceRecord.Value
-				m.Records = append(
-					m.Records,
-					Record{
-						AWSService:  "Route53",
-						Name:        recordName,
-						Type:        recordType,
-						Value:       aws.ToString(recordValue),
-						PrivateZone: privateZone,
-					})
+				if record.AliasTarget != nil {
+					m.Records = append(
+						m.Records,
+						Record{
+							AWSService:  "Route53",
+							Name:        recordName,
+							Type:        fmt.Sprintf("Alias[%s]", recordType),
+							Value:       aws.ToString(record.AliasTarget.DNSName),
+							PrivateZone: privateZone,
+						})
+				} else {
+					m.Records = append(
+						m.Records,
+						Record{
+							AWSService:  "Route53",
+							Name:        recordName,
+							Type:        recordType,
+							Value:       aws.ToString(recordValue),
+							PrivateZone: privateZone,
+						})
+				}
 
 			}
 		}


### PR DESCRIPTION
#### Card

Adds support for Alias records in the `cloudfox aws route53` command. These records are currently not shown, and you could miss interesting things because of that.

#### Details

AWS Route53 supports special DNS records called Alias ([docs](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html)). They are configured like CNAMEs and allow you to point records like `mybucket.company.com` to AWS resources like an S3 bucket. When resolved, they behave like A/AAAA records. 

The SDK reports these records in a special field. Therefore cloudfox currently does not output them. The PR checks adds them as a special case. They get printed out with type `Alias[A]` or `Alias[AAAA]` and the value will be some identifier of the AWS resource the record points to. 
