### PR TITLE
Fix service slug mismatches for awsservicemap v1.1.0

### DIFF
--- a/aws/directory-services.go
+++ b/aws/directory-services.go
@@ -198,7 +198,7 @@ func (m *DirectoryModule) executeChecks(r string, wg *sync.WaitGroup, semaphore 
 			JsonFileSource: "DOWNLOAD_FROM_AWS",
 		}
 	}
-	res, err := servicemap.IsServiceInRegion("clouddirectory", r)
+	res, err := servicemap.IsServiceInRegion("directoryservice", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}

--- a/aws/endpoints.go
+++ b/aws/endpoints.go
@@ -293,7 +293,7 @@ func (m *EndpointsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore 
 		wg.Add(1)
 		go m.getEksClustersPerRegion(r, wg, semaphore, dataReceiver)
 	}
-	res, err = servicemap.IsServiceInRegion("mq", r)
+	res, err = servicemap.IsServiceInRegion("amazon-mq", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -302,7 +302,7 @@ func (m *EndpointsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore 
 		wg.Add(1)
 		go m.getMqBrokersPerRegion(r, wg, semaphore, dataReceiver)
 	}
-	res, err = servicemap.IsServiceInRegion("es", r)
+	res, err = servicemap.IsServiceInRegion("opensearch-service", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -320,7 +320,7 @@ func (m *EndpointsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore 
 		wg.Add(1)
 		m.getGrafanaEndPointsPerRegion(r, wg, semaphore, dataReceiver)
 	}
-	res, err = servicemap.IsServiceInRegion("elb", r)
+	res, err = servicemap.IsServiceInRegion("elasticloadbalancing", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -378,7 +378,7 @@ func (m *EndpointsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore 
 	wg.Add(1)
 	go m.getAppRunnerEndpointsPerRegion(r, wg, semaphore, dataReceiver)
 
-	res, err = servicemap.IsServiceInRegion("lightsail", r)
+	res, err = servicemap.IsServiceInRegion("amazonlightsail.com", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}

--- a/aws/env-vars.go
+++ b/aws/env-vars.go
@@ -310,7 +310,7 @@ func (m *EnvsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore chan 
 	wg.Add(1)
 	go m.getAppRunnerEnvironmentVariablesPerRegion(r, wg, semaphore, dataReceiver)
 
-	res, err = servicemap.IsServiceInRegion("lightsail", r)
+	res, err = servicemap.IsServiceInRegion("amazonlightsail.com", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -320,7 +320,7 @@ func (m *EnvsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore chan 
 		go m.getLightsailEnvironmentVariablesPerRegion(r, wg, semaphore, dataReceiver)
 	}
 
-	res, err = servicemap.IsServiceInRegion("sagemaker", r)
+	res, err = servicemap.IsServiceInRegion("sagemaker-ai", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}

--- a/aws/inventory.go
+++ b/aws/inventory.go
@@ -599,7 +599,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.getEKSNodeGroupsPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("elb", r)
+	res, err = servicemap.IsServiceInRegion("elasticloadbalancing", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -645,7 +645,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.GetEMRInstancesPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("es", r)
+	res, err = servicemap.IsServiceInRegion("opensearch-service", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -682,7 +682,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 
 	}
 
-	res, err = servicemap.IsServiceInRegion("kinesis", r)
+	res, err = servicemap.IsServiceInRegion("streams", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -703,7 +703,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.getLambdaFunctionsPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("lightsail", r)
+	res, err = servicemap.IsServiceInRegion("amazonlightsail.com", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -713,7 +713,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.getLightsailInstancesAndContainersPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("mq", r)
+	res, err = servicemap.IsServiceInRegion("amazon-mq", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -743,7 +743,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.getRedshiftClustersPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("secretsmanager", r)
+	res, err = servicemap.IsServiceInRegion("secrets-manager", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -773,7 +773,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.getSQSQueuesPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("ssm", r)
+	res, err = servicemap.IsServiceInRegion("systems-manager", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -783,7 +783,7 @@ func (m *Inventory2Module) executeChecks(r string, wg *sync.WaitGroup, semaphore
 		go m.getSSMParametersPerRegion(r, wg, semaphore)
 	}
 
-	res, err = servicemap.IsServiceInRegion("stepfunctions", r)
+	res, err = servicemap.IsServiceInRegion("step-functions", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}

--- a/aws/network-ports.go
+++ b/aws/network-ports.go
@@ -318,7 +318,7 @@ func (m *NetworkPortsModule) executeChecks(r string, wg *sync.WaitGroup, dataRec
 		m.getElastiCacheNetworkPortsPerRegion(r, dataReceiver)
 	}
 
-	res, err = servicemap.IsServiceInRegion("elb", r)
+	res, err = servicemap.IsServiceInRegion("elasticloadbalancing", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -327,7 +327,7 @@ func (m *NetworkPortsModule) executeChecks(r string, wg *sync.WaitGroup, dataRec
 		m.getLBNetworkPortsPerRegion(r, dataReceiver)
 	}
 
-	res, err = servicemap.IsServiceInRegion("lightsail", r)
+	res, err = servicemap.IsServiceInRegion("amazonlightsail.com", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}

--- a/aws/resource-trusts.go
+++ b/aws/resource-trusts.go
@@ -272,7 +272,7 @@ func (m *ResourceTrustsModule) executeChecks(r string, wg *sync.WaitGroup, semap
 		m.getEFSfilesystemPoliciesPerRegion(r, wg, semaphore, dataReceiver)
 	}
 
-	res, err = servicemap.IsServiceInRegion("secretsmanager", r)
+	res, err = servicemap.IsServiceInRegion("secrets-manager", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -329,7 +329,7 @@ func (m *ResourceTrustsModule) executeChecks(r string, wg *sync.WaitGroup, semap
 	}
 
 	if m.OpenSearchClient != nil {
-		res, err = servicemap.IsServiceInRegion("es", r)
+		res, err = servicemap.IsServiceInRegion("opensearch-service", r)
 		if err != nil {
 			m.modLog.Error(err)
 		}

--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -200,7 +200,7 @@ func (m *SecretsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore ch
 			JsonFileSource: "DOWNLOAD_FROM_AWS",
 		}
 	}
-	res, err := servicemap.IsServiceInRegion("secretsmanager", r)
+	res, err := servicemap.IsServiceInRegion("secrets-manager", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}
@@ -209,7 +209,7 @@ func (m *SecretsModule) executeChecks(r string, wg *sync.WaitGroup, semaphore ch
 		wg.Add(1)
 		go m.getSecretsManagerSecretsPerRegion(r, wg, semaphore, dataReceiver)
 	}
-	res, err = servicemap.IsServiceInRegion("ssm", r)
+	res, err = servicemap.IsServiceInRegion("systems-manager", r)
 	if err != nil {
 		m.modLog.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -218,5 +218,5 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.77.0
+	google.golang.org/grpc v1.79.3
 )

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/dominikbraun/graph v0.23.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.13.5-0.20251024222203-75eaa193e329 h1:K+fnvUM0VZ7ZFJf0n4L/BRlnsb9pL/GuDG6FqaH+PwM=
-github.com/envoyproxy/go-control-plane v0.13.5-0.20251024222203-75eaa193e329/go.mod h1:Alz8LEClvR7xKsrq3qzoc4N0guvVNSS8KmSChGYr9hs=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
@@ -601,8 +601,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.77.0 h1:wVVY6/8cGA6vvffn+wWK5ToddbgdU3d8MNENr4evgXM=
-google.golang.org/grpc v1.77.0/go.mod h1:z0BY1iVj0q8E1uSQCjL9cppRj+gnZjzDnzV0dHhrNig=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
awsservicemap v1.1.0 changed from a hash-based service ID format to a
  URL slug-based format. Several AWS commands were still using old-style
  slugs that no longer match, causing IsServiceInRegion to silently return
  false for every region — meaning those services were never enumerated at all.

  For example, the `secrets` command returned zero results despite Secrets
  Manager entries existing in the account, because "secretsmanager" no longer
  matched (the correct slug is now "secrets-manager", derived from
  https://aws.amazon.com/secrets-manager/).

  Slug corrections applied across 7 files:

  | Old slug       | New slug              | Affected commands                      |
  |----------------|-----------------------|----------------------------------------|
  | secretsmanager | secrets-manager       | secrets, resource-trusts, inventory    |
  | ssm            | systems-manager       | secrets, inventory                     |
  | elb            | elasticloadbalancing  | endpoints, inventory, network-ports    |
  | es             | opensearch-service    | endpoints, inventory, resource-trusts  |
  | mq             | amazon-mq             | endpoints, inventory                   |
  | stepfunctions  | step-functions        | inventory                              |
  | sagemaker      | sagemaker-ai          | env-vars                               |
  | clouddirectory | directoryservice      | directory-services                     |
  | kinesis        | streams               | inventory                              |
  | lightsail      | amazonlightsail.com   | endpoints, env-vars, network-ports     |

  Note: cloud9 and datapipeline are absent from the AWS service map entirely
  (both deprecated by AWS), so those returning false is correct behavior.