### PR TITLE
Fix --pmapper-data-basepath ignored in all-checks for EC2 user data module

### DIFF
--- a/cli/aws.go
+++ b/cli/aws.go
@@ -2252,6 +2252,7 @@ func runAllChecksCommand(cmd *cobra.Command, args []string) {
 			WrapTable:              AWSWrapTable,
 			AWSOutputType:          AWSOutputType,
 			AWSTableCols:           AWSTableCols,
+			PmapperDataBasePath:   PmapperDataBasePath,
 		}
 		ec2UserData.Instances(InstancesFilter, AWSOutputDirectory, Verbosity)
 		envsMod := aws.EnvsModule{


### PR DESCRIPTION
The EC2 user data InstancesModule in runAllChecksCommand was not receiving
the PmapperDataBasePath parameter, causing the --pmapper-data-basepath flag
to be ignored when running all-checks.

Fix: Add PmapperDataBasePath: PmapperDataBasePath to the ec2UserData struct
initialization in runAllChecksCommand.
