### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
 
-      - name: Go 1.21
-        uses: actions/setup-go@v4
+      - name: Go 1.25
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.20
+          go-version: ^1.25
         id: go
 
       - id: install-secret-key
@@ -28,7 +28,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Git Fetch Tags
         run: git fetch --prune --unshallow --tags -f
@@ -39,9 +39,6 @@ jobs:
 
        
       - name: Release binaries
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
-          files: |
-            ./cloudfox/*
+          files: ./cloudfox/*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,6 +11,6 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: pip install --user codespell
     - run: codespell --ignore-words-list="aks,referers,invokable" --skip="*.sum"


### PR DESCRIPTION
## Summary

Updates all GitHub Actions workflows to use Node 24 compatible action versions before the June 2, 2026 enforcement deadline.

### Changes
- `actions/checkout` v4 -> v6 (both workflows)
- `actions/setup-go` v4 -> v5 (autorelease)
- Go version `^1.20` -> `^1.25` (match project's current Go version)
- Replaced `marvinpinto/action-automatic-releases@latest` with `softprops/action-gh-release@v2` (actively maintained, Node 24 compatible)

### Why
Node.js 20 actions are deprecated per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):
- June 2, 2026: Actions forced to run with Node 24
- September 16, 2026: Node 20 removed from runners

### Testing
No binary changes. Workflow behavior is identical — release trigger (`v*` tags) and codespell checks are unchanged.