### PR TITLE
Fixed bugs in aws outbound-assumed-roles

### DIFF
--- a/aws/outbound-assumed-roles.go
+++ b/aws/outbound-assumed-roles.go
@@ -307,9 +307,9 @@ func (m *OutboundAssumedRolesModule) executeChecks(r string, wg *sync.WaitGroup,
 		m.modLog.Error(err)
 	}
 	if res {
-		// wg.Add(1)
-		// m.CommandCounter.IncrTotal()
-		// m.getAssumeRoleLogEntriesPerRegion(r, wg, semaphore, dataReceiver)
+		wg.Add(1)
+		m.CommandCounter.IncrTotal()
+		m.getAssumeRoleLogEntriesPerRegion(r, wg, semaphore, dataReceiver)
 		wg.Add(1)
 		m.CommandCounter.IncrTotal()
 		m.getCrossAccountBatchGetImageEntriesPerRegion(r, wg, semaphore, dataReceiver)
@@ -334,9 +334,13 @@ func (m *OutboundAssumedRolesModule) getAssumeRoleLogEntriesPerRegion(r string, 
 	//var LookupAttribute types.LookupAttribute
 	var pages int
 
-	days := 0 - m.Days
+	// Ensure input days is absolute value for lookback calculation. 
+	days := m.Days
+	if (days < 0) {
+		days = -days
+	}
 	endTime := aws.Time(time.Now())
-	startTime := endTime.AddDate(0, 0, days)
+	startTime := endTime.AddDate(0, 0, -days)
 	for {
 		LookupEvents, err := m.CloudTrailClient.LookupEvents(
 			context.TODO(),
@@ -427,21 +431,25 @@ func (m *OutboundAssumedRolesModule) getCrossAccountBatchGetImageEntriesPerRegio
 	//var LookupAttribute types.LookupAttribute
 	var pages int
 
-	days := 0 - m.Days
+	// Ensure input days is absolute value for lookback calculation. 
+	days := m.Days
+	if (days < 0) {
+		days = -days
+	}
 	endTime := aws.Time(time.Now())
-	startTime := endTime.AddDate(0, 0, days)
+	startTime := endTime.AddDate(0, 0, -days)
 	for {
 		LookupEvents, err := m.CloudTrailClient.LookupEvents(
 			context.TODO(),
 			&cloudtrail.LookupEventsInput{
 				EndTime:   endTime,
 				StartTime: &startTime,
-				// LookupAttributes: []cloudtrailTypes.LookupAttribute{
-				// 	{
-				// 		AttributeKey:   cloudtrailTypes.LookupAttributeKeyEventName,
-				// 		AttributeValue: aws.String("BatchGetImage"),
-				// 	},
-				// },
+				LookupAttributes: []cloudtrailTypes.LookupAttribute{
+					{
+				 		AttributeKey:   cloudtrailTypes.LookupAttributeKeyEventName,
+				 		AttributeValue: aws.String("BatchGetImage"),
+					},
+				},
 				NextToken: PaginationControl,
 			},
 

--- a/cli/aws.go
+++ b/cli/aws.go
@@ -2510,7 +2510,7 @@ func init() {
 	SNSCommand.Flags().BoolVarP(&StoreSNSAccessPolicies, "policies", "", false, "Store all flagged access policies along with the output")
 
 	//  outbound-assumed-roles module flags
-	OutboundAssumedRolesCommand.Flags().IntVarP(&OutboundAssumedRolesDays, "days", "d", -7, "How many days of CloudTrail events should we go back and look at.")
+	OutboundAssumedRolesCommand.Flags().IntVarP(&OutboundAssumedRolesDays, "days", "d", 7, "How many days of CloudTrail events should we go back and look at.")
 
 	//  iam-simulator module flags
 	IamSimulatorCommand.Flags().StringVar(&SimulatorPrincipal, "principal", "", "Principal Arn")


### PR DESCRIPTION
#### Card
Fixed bugs in aws outbound-assumed-roles

#### Details
This PR involves 4 related bug fixes, identified when cloudtrail:LookupEvents were failing with AWS error "InvalidTimeRangeException: The start time precedes the end time" after running "cloudfox aws outbound-assumed-roles"

1) Fixed incorrect startTime calculation in /aws/outbound-assumed-roles.go (both locations) to calculate absolutel value of m.Days to properly handle potential negative numbers

2) Changed -7 to 7 when building OutboundAssumedRolesCommand in /cli/aws.go

3) Uncommented LookupAttributes for "BatchGetImage" in cloudtrail:LookupEvents call in getCrossAccountBatchGetImageEntriesPerRegion method (assuming it was previously commented when debugging startTime/endTime issue now fixed in #1)

4) Uncommented getAssumeRoleLogEntriesPerRegion method call in executeChecks method (assuming it was previously commented when debugging startTime/endTime issue now fixed in #1)

Confirmed both AssumedRole and BatchGetImage methods are now running without issue when executing "cloudfox aws outbound-assumed-roles"
